### PR TITLE
fix: 장바구니 컴포넌트가 렌더링되지 않을 수 있는 문제 수정

### DIFF
--- a/package/pyconkr-shop/apis/index.ts
+++ b/package/pyconkr-shop/apis/index.ts
@@ -86,7 +86,7 @@ namespace ShopAPIRoute {
    * @returns 현재 장바구니 상태
    */
   export const retrieveCart = () =>
-    shopAPIClient.get<ShopAPISchema.Order>("v1/orders/cart/");
+    shopAPIClient.get<ShopAPISchema.Order | ShopAPISchema.EmptyObject>("v1/orders/cart/");
 
   /**
    * 장바구니에 상품을 추가합니다.

--- a/package/pyconkr-shop/schemas/index.ts
+++ b/package/pyconkr-shop/schemas/index.ts
@@ -1,6 +1,8 @@
 import * as R from "remeda";
 
 namespace ShopAPISchema {
+  export type EmptyObject = Record<string, never>;
+
   export type DetailedErrorSchema = {
     code: string;
     detail: string;

--- a/src/debug/page/shop_component/cart.tsx
+++ b/src/debug/page/shop_component/cart.tsx
@@ -80,7 +80,7 @@ export const ShopCartList: React.FC<{ onPaymentCompleted?: () => void; }> = ({ o
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const { data } = ShopAPIHook.useCart();
 
-      return data.products.length === 0
+      return !data.hasOwnProperty('products') || data.products.length === 0
         ? <Typography variant="body1" color="error">장바구니가 비어있어요!</Typography>
         : <>
           {data.products.map((prodRel) => <ShopCartItem key={prodRel.id} cartProdRel={prodRel} disabled={disabled} removeItemFromCartFunc={removeItemFromCart} />)}


### PR DESCRIPTION
# 주요 변경 사항
- 고객이 상품을 한번도 담지 않은 경우, 백엔드에서 장바구니(`Cart`)가 아직 초기화되지 않았을 수 있습니다.
  이때 백엔드에서 받아온 장바구니 정보는 빈 `object`라서 `data.products.length`에 접근할 수 없게 되어 에러가 발생하고, `ErrorBoundary`에 걸리게 됩니다.
- 이를 수정합니다.