### PR TITLE
fix: @frontend/shop의 target build 버전을 올림

### DIFF
--- a/apps/pyconkr/index.html
+++ b/apps/pyconkr/index.html
@@ -39,7 +39,7 @@
     <meta name="robots" content="index, follow" />
 
     <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
-      <link rel="stylesheet" href="github-markdown.css">
+    <link rel="stylesheet" href="github-markdown.css">
 
     <title>PyCon Korea 2025</title>
   </head>

--- a/packages/common/src/components/dynamic_route.tsx
+++ b/packages/common/src/components/dynamic_route.tsx
@@ -6,10 +6,11 @@ import { CircularProgress } from '@mui/material';
 import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 import styled from '@emotion/styled';
-import Components from '../components';
 import Hooks from "../hooks";
 import Schemas from "../schemas";
 import Utils from '../utils';
+import { ErrorFallback } from './error_handler';
+import { MDXRenderer } from './mdx';
 
 const InitialPageStyle: React.CSSProperties = {
   width: '100%',
@@ -31,7 +32,7 @@ export const PageRenderer: React.FC<{ id: string }> = ({ id }) => {
     {
       data.sections.map(
         (s) => <div style={{ ...InitialSectionStyle, ...Utils.parseCss(s.css) }} key={s.id}>
-          <Components.MDXRenderer text={s.body} />
+          <MDXRenderer text={s.body} />
         </div>
       )
     }
@@ -71,7 +72,7 @@ const FullPage = styled.div`
 `
 
 export const DynamicRoutePage: React.FC = () => <FullPage>
-  <ErrorBoundary fallback={Components.ErrorFallback}>
+  <ErrorBoundary fallback={ErrorFallback}>
     <Suspense fallback={<CircularProgress />}>
       <AsyncDynamicRoutePage />
     </Suspense>

--- a/packages/shop/tsconfig.json
+++ b/packages/shop/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-      "target": "ES2019",
+      "target": "ES2021",
       "module": "ESNext",
       "moduleResolution": "node",
       "declaration": true,


### PR DESCRIPTION
# 주요 변경 사항
- @frontend/shop의 target build 버전을 ES2021로 올립니다.
- @frontend/common의 circular dependency 이슈를 해소합니다.