### PR TITLE
chore: 어드민의 사소한 이슈들 수정

### DIFF
--- a/apps/pyconkr-admin/src/components/layouts/admin_list.tsx
+++ b/apps/pyconkr-admin/src/components/layouts/admin_list.tsx
@@ -10,6 +10,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Typography,
 } from "@mui/material";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import * as React from "react";
@@ -43,6 +44,10 @@ const InnerAdminList: React.FC<AdminListProps> = ErrorBoundary.with(
 
     return (
       <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }}>
+        <Typography variant="h5">
+          {app.toUpperCase()} &gt; {resource.toUpperCase()} &gt; 목록
+        </Typography>
+        <br />
         <Box>
           <Button
             variant="contained"

--- a/apps/pyconkr-admin/src/components/layouts/global.tsx
+++ b/apps/pyconkr-admin/src/components/layouts/global.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, Menu } from "@mui/icons-material";
 import {
+  Backdrop,
   Box,
   CssBaseline,
   Divider,
@@ -163,6 +164,7 @@ export const Layout: React.FC<{ routes: RouteDef[] }> = ({ routes }) => {
             <Outlet />
           </PageInnerContainer>
         </PageOuterContainer>
+        <Backdrop open={state.showDrawer} onClick={toggleDrawer} />
       </Box>
     </Box>
   );

--- a/apps/pyconkr-admin/src/components/layouts/global.tsx
+++ b/apps/pyconkr-admin/src/components/layouts/global.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, Menu } from "@mui/icons-material";
 import {
   Backdrop,
   Box,
+  Chip,
   CssBaseline,
   Divider,
   IconButton,
@@ -22,16 +23,23 @@ import { Outlet, useNavigate } from "react-router-dom";
 
 import { MiniVariantAppBar, MiniVariantDrawer } from "./sidebar";
 
-export type RouteDef = {
-  icon: typeof SvgIcon;
-  title: string;
-  app: string;
-  resource: string;
-  route?: string; // If specified, this will be used as the route instead of the default one
-  isAdminPage?: boolean;
-  hideOnSidebar?: boolean;
-  placeOnBottom?: boolean;
-};
+export type RouteDef =
+  | {
+      type: "routeDefinition";
+      key: string; // Unique key for the route
+      icon: typeof SvgIcon;
+      title: string;
+      app: string;
+      resource: string;
+      route?: string; // If specified, this will be used as the route instead of the default one
+      hideOnSidebar?: boolean;
+      placeOnBottom?: boolean;
+    }
+  | {
+      type: "separator";
+      key: string; // Unique key for the route
+      title: string;
+    };
 
 type LayoutState = {
   showDrawer: boolean;
@@ -65,35 +73,61 @@ export const Layout: React.FC<{ routes: RouteDef[] }> = ({ routes }) => {
   const toggleDrawer = () =>
     dispatch((ps) => ({ ...ps, showDrawer: !ps.showDrawer }));
 
-  const SidebarItem: React.FC<{ routeInfo: RouteDef }> = ({ routeInfo }) => (
-    <ListItem
-      key={`${routeInfo.app}-${routeInfo.resource}`}
-      sx={routeInfo.placeOnBottom ? { marginTop: "auto" } : {}}
-      disablePadding
-    >
-      <ListItemButton
-        sx={{
-          minHeight: 48,
-          px: 2.5,
-          justifyContent: state.showDrawer ? "initial" : "center",
-        }}
-        onClick={() =>
-          navigate(routeInfo.route || `/${routeInfo.app}/${routeInfo.resource}`)
-        }
+  const SidebarItem: React.FC<{ routeInfo: RouteDef }> = ({ routeInfo }) =>
+    routeInfo.type === "separator" ? (
+      <ListItem key={routeInfo.title} disablePadding sx={{ minHeight: 48 }}>
+        {state.showDrawer ? (
+          <ListItemButton disabled>
+            <ListItemText primary={routeInfo.title} />
+          </ListItemButton>
+        ) : (
+          <Stack
+            alignItems="center"
+            sx={(t) => ({
+              width: t.spacing(7),
+              [t.breakpoints.up("sm")]: { width: t.spacing(8) },
+            })}
+          >
+            <Chip
+              label={routeInfo.title}
+              variant="outlined"
+              size="small"
+              sx={{ flexGrow: 0 }}
+            />
+          </Stack>
+        )}
+      </ListItem>
+    ) : (
+      <ListItem
+        key={`${routeInfo.app}-${routeInfo.resource}`}
+        sx={routeInfo.placeOnBottom ? { marginTop: "auto" } : {}}
+        disablePadding
       >
-        <ListItemIcon
+        <ListItemButton
           sx={{
-            minWidth: 0,
-            justifyContent: "center",
-            mr: state.showDrawer ? 3 : "auto",
+            minHeight: 48,
+            px: 2.5,
+            justifyContent: state.showDrawer ? "initial" : "center",
           }}
+          onClick={() =>
+            navigate(
+              routeInfo.route || `/${routeInfo.app}/${routeInfo.resource}`
+            )
+          }
         >
-          <routeInfo.icon />
-        </ListItemIcon>
-        {state.showDrawer && <ListItemText primary={routeInfo.title} />}
-      </ListItemButton>
-    </ListItem>
-  );
+          <ListItemIcon
+            sx={{
+              minWidth: 0,
+              justifyContent: "center",
+              mr: state.showDrawer ? 3 : "auto",
+            }}
+          >
+            <routeInfo.icon />
+          </ListItemIcon>
+          {state.showDrawer && <ListItemText primary={routeInfo.title} />}
+        </ListItemButton>
+      </ListItem>
+    );
 
   const menuButtonStyle: (t: Theme) => React.CSSProperties = (t) => ({
     width: `calc(${t.spacing(7)} + 1px)`,
@@ -152,9 +186,9 @@ export const Layout: React.FC<{ routes: RouteDef[] }> = ({ routes }) => {
           <Divider />
           <Stack sx={{ height: "100%" }}>
             {routes
-              .filter((r) => !r.hideOnSidebar)
+              .filter((r) => r.type === "separator" || !r.hideOnSidebar)
               .map((r) => (
-                <SidebarItem key={`${r.app}-${r.resource}`} routeInfo={r} />
+                <SidebarItem key={r.key} routeInfo={r} />
               ))}
           </Stack>
         </MiniVariantDrawer>

--- a/apps/pyconkr-admin/src/routes.tsx
+++ b/apps/pyconkr-admin/src/routes.tsx
@@ -19,27 +19,42 @@ import { AdminCMSPageEditor } from "./components/pages/page/editor";
 
 export const RouteDefinitions: RouteDef[] = [
   {
+    type: "separator",
+    key: "cms-separator",
+    title: "CMS",
+  },
+  {
+    type: "routeDefinition",
+    key: "cms-sitemap",
     icon: AccountTree,
-    title: "CMS - 사이트맵 관리",
+    title: "사이트맵 관리",
     app: "cms",
     resource: "sitemap",
-    isAdminPage: true,
   },
   {
+    type: "routeDefinition",
+    key: "cms-page",
     icon: Article,
-    title: "CMS - 페이지 관리",
+    title: "페이지 관리",
     app: "cms",
     resource: "page",
-    isAdminPage: true,
   },
   {
+    type: "separator",
+    key: "file-separator",
+    title: "파일",
+  },
+  {
+    type: "routeDefinition",
+    key: "file-publicfile",
     icon: FilePresent,
     title: "외부 노출 파일 관리",
     app: "file",
     resource: "publicfile",
-    isAdminPage: true,
   },
   {
+    type: "routeDefinition",
+    key: "user-userext",
     icon: AccountCircle,
     title: "로그인 / 로그아웃",
     app: "user",
@@ -62,7 +77,7 @@ const buildDefaultRoutes = (app: string, resource: string) => {
 };
 
 export const RegisteredRoutes = {
-  ...RouteDefinitions.filter((r) => r.isAdminPage).reduce(
+  ...RouteDefinitions.filter((r) => r.type === "routeDefinition").reduce(
     (acc, { app, resource }) => {
       return {
         ...acc,


### PR DESCRIPTION
# 주요 변경 사항
![CleanShot 2025-06-01 at 15 58 52@2x](https://github.com/user-attachments/assets/ad97a5bd-5656-4b19-a382-fc9ae8434062)
![CleanShot 2025-06-01 at 15 58 45@2x](https://github.com/user-attachments/assets/a6c87d58-c45d-4396-b3b4-757308d31d6e)
- 목록 화면에서 어떤 항목의 목록인지를 보이도록 수정합니다.
- 좌측 메뉴가 열릴 시, backdrop으로 화면을 감싸도록 수정합니다.
- 좌측 메뉴에 구분자를 추가합니다.