### PR TITLE
feat: `hr`에 색상 적용

### DIFF
--- a/packages/common/src/components/mdx.tsx
+++ b/packages/common/src/components/mdx.tsx
@@ -20,6 +20,7 @@ import * as R from "remeda";
 
 import Hooks from "../hooks";
 import { ErrorFallback } from "./error_handler";
+import { StyledDivider } from "./mdx_components/styled_divider";
 
 const REGISTERED_KEYWORDS = [
   "import",
@@ -51,6 +52,7 @@ const CustomMDXComponents: MDXComponents = {
   h5: (props) => <h5 {...props} />,
   h6: (props) => <h6 {...props} />,
   strong: (props) => <strong {...props} />,
+  hr: (props) => <StyledDivider {...props} />,
   em: (props) => <em {...props} />,
   ul: (props) => <ul {...props} />,
   ol: (props) => <ol {...props} />,

--- a/packages/common/src/components/mdx_components/styled_divider.tsx
+++ b/packages/common/src/components/mdx_components/styled_divider.tsx
@@ -1,0 +1,9 @@
+import { Divider, DividerProps, useTheme } from "@mui/material";
+import * as React from "react";
+
+export const StyledDivider: React.FC<DividerProps> = (props) => {
+  const { palette } = useTheme();
+  const sx = { borderColor: palette.primary.dark, ...props.sx };
+  const newProps = { ...props, sx };
+  return <Divider {...newProps} />;
+};


### PR DESCRIPTION
# 주요 변경 사항
![CleanShot 2025-06-02 at 07 45 47@2x](https://github.com/user-attachments/assets/dd7b9631-a1b1-4464-85b1-7935ab5a05df)
- `divider`에 색상을 추가합니다. ~참 쉽죠?~