### PR TITLE
fix: MDX 내의 모든 `h*` 태그에서 margin 제거

### DIFF
--- a/packages/common/src/components/mdx.tsx
+++ b/packages/common/src/components/mdx.tsx
@@ -45,12 +45,12 @@ const REGISTERED_KEYWORDS = [
 ];
 
 const CustomMDXComponents: MDXComponents = {
-  h1: (props) => <h1 {...props} />,
-  h2: (props) => <h2 {...props} />,
-  h3: (props) => <h3 {...props} />,
-  h4: (props) => <h4 {...props} />,
-  h5: (props) => <h5 {...props} />,
-  h6: (props) => <h6 {...props} />,
+  h1: (props) => <h1 style={{ margin: 0 }} {...props} />,
+  h2: (props) => <h2 style={{ margin: 0 }} {...props} />,
+  h3: (props) => <h3 style={{ margin: 0 }} {...props} />,
+  h4: (props) => <h4 style={{ margin: 0 }} {...props} />,
+  h5: (props) => <h5 style={{ margin: 0 }} {...props} />,
+  h6: (props) => <h6 style={{ margin: 0 }} {...props} />,
   strong: (props) => <strong {...props} />,
   hr: (props) => <StyledDivider {...props} />,
   em: (props) => <em {...props} />,

--- a/packages/common/src/components/mdx.tsx
+++ b/packages/common/src/components/mdx.tsx
@@ -21,6 +21,7 @@ import * as R from "remeda";
 import Hooks from "../hooks";
 import { ErrorFallback } from "./error_handler";
 import { StyledDivider } from "./mdx_components/styled_divider";
+import { SubContentContainer } from "./mdx_components/sub_content_container";
 
 const REGISTERED_KEYWORDS = [
   "import",
@@ -68,6 +69,7 @@ const CustomMDXComponents: MDXComponents = {
   tr: (props) => <TableRow {...props} />,
   th: (props) => <TableCell {...props} />,
   td: (props) => <TableCell {...props} />,
+  Content: (props) => <SubContentContainer {...props} />,
 };
 
 const lineFormatterForMDX = (line: string) => {

--- a/packages/common/src/components/mdx_components/sub_content_container.tsx
+++ b/packages/common/src/components/mdx_components/sub_content_container.tsx
@@ -1,0 +1,6 @@
+import { Box } from "@mui/material";
+import * as React from "react";
+
+export const SubContentContainer: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <Box sx={(theme) => ({ px: theme.spacing(2), py: theme.spacing(4) })}>{children}</Box>
+);


### PR DESCRIPTION
# 주요 변경 사항
![CleanShot 2025-06-02 at 07 55 15@2x](https://github.com/user-attachments/assets/e4233614-b10d-4ab4-b3d2-52d7cb7fbc12)
![CleanShot 2025-06-02 at 07 55 21@2x](https://github.com/user-attachments/assets/8864a963-87f7-417a-8a9a-39e0994da6b8)
- `h*` 태그들에서 `margin`을 `0`으로 설정합니다.