### PR TITLE
feat : 모바일 GNB 구현

### DIFF
--- a/apps/pyconkr/src/components/layout/Header/Mobile/HamburgerButton.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/HamburgerButton.tsx
@@ -1,0 +1,46 @@
+import { IconButton, styled } from "@mui/material";
+import * as React from "react";
+
+interface HamburgerButtonProps {
+  isOpen: boolean;
+  onClick: () => void;
+  isMainPath?: boolean;
+}
+
+export const HamburgerButton: React.FC<HamburgerButtonProps> = ({ isOpen, onClick, isMainPath = true }) => {
+  return (
+    <StyledIconButton onClick={onClick} isMainPath={isMainPath}>
+      <HamburgerIcon isOpen={isOpen} isMainPath={isMainPath}>
+        <span />
+        <span />
+        <span />
+      </HamburgerIcon>
+    </StyledIconButton>
+  );
+};
+
+const StyledIconButton = styled(IconButton)<{ isMainPath: boolean }>(({ theme, isMainPath }) => ({
+  padding: 0,
+  width: 26,
+  height: 18,
+  color: isMainPath ? theme.palette.mobileHeader.main.text : theme.palette.mobileHeader.sub.text,
+}));
+
+const HamburgerIcon = styled("div")<{ isOpen: boolean; isMainPath: boolean }>(({ isOpen, theme, isMainPath }) => ({
+  width: 26,
+  height: 18,
+  position: "relative",
+  cursor: "pointer",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "space-between",
+
+  "& span": {
+    display: "block",
+    height: isOpen ? 3 : 2,
+    width: "100%",
+    backgroundColor: isMainPath ? theme.palette.mobileHeader.main.text : theme.palette.mobileHeader.sub.text,
+    borderRadius: 1,
+    transition: "height 0.3s ease",
+  },
+}));

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
@@ -56,7 +56,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ isNavigationOpen = f
 };
 
 const MobileHeaderContainer = styled("header")<{ isOpen: boolean; isMainPath: boolean }>(({ theme, isOpen, isMainPath }) => ({
-  position: "fixed",
+  position: isMainPath ? "fixed" : "sticky",
   top: 0,
   left: 0,
   right: 0,
@@ -71,11 +71,11 @@ const MobileHeaderContainer = styled("header")<{ isOpen: boolean; isMainPath: bo
   padding: "15px 23px",
 
   backgroundColor: isMainPath ? "rgba(182, 216, 215, 0.1)" : "#B6D8D7",
-  backdropFilter: "blur(8px)",
-  WebkitBackdropFilter: "blur(8px)",
+  backdropFilter: isMainPath ? "blur(8px)" : "none",
+  WebkitBackdropFilter: isMainPath ? "blur(8px)" : "none",
   color: isMainPath ? "white" : "rgba(18, 109, 127, 0.6)",
 
-  zIndex: theme.zIndex.appBar + 100000,
+  zIndex: isMainPath ? theme.zIndex.appBar + 100000 : theme.zIndex.appBar,
 }));
 
 const LeftContent = styled(Box)({

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
@@ -14,7 +14,7 @@ interface MobileHeaderProps {
 }
 
 export const MobileHeader: React.FC<MobileHeaderProps> = ({ isNavigationOpen = false, onToggleNavigation }) => {
-  const { siteMapNode, language } = useAppContext();
+  const { siteMapNode } = useAppContext();
   const location = useLocation();
   const [internalNavigationOpen, setInternalNavigationOpen] = React.useState(false);
 
@@ -22,11 +22,6 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ isNavigationOpen = f
   const toggleNavigation = onToggleNavigation || (() => setInternalNavigationOpen(!internalNavigationOpen));
 
   const isMainPath = location.pathname === "/";
-
-  const handleLanguageChange = (newLanguage: string) => {
-    // TODO: 언어 변경 로직 구현
-    console.log("Language changed to:", newLanguage);
-  };
 
   return (
     <>
@@ -52,7 +47,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({ isNavigationOpen = f
           </LogoAndTextContainer>
         </LeftContent>
 
-        <MobileLanguageToggle currentLanguage={language} onLanguageChange={handleLanguageChange} isMainPath={isMainPath} />
+        <MobileLanguageToggle isMainPath={isMainPath} />
       </MobileHeaderContainer>
 
       <MobileNavigation isOpen={navigationOpen} onClose={() => toggleNavigation()} siteMapNode={siteMapNode} />

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileHeader.tsx
@@ -1,0 +1,95 @@
+import * as Common from "@frontend/common";
+import { Box, Stack, styled, Typography } from "@mui/material";
+import * as React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import { HamburgerButton } from "./HamburgerButton";
+import { MobileLanguageToggle } from "./MobileLanguageToggle";
+import { MobileNavigation } from "./MobileNavigation";
+import { useAppContext } from "../../../../contexts/app_context";
+
+interface MobileHeaderProps {
+  isNavigationOpen?: boolean;
+  onToggleNavigation?: () => void;
+}
+
+export const MobileHeader: React.FC<MobileHeaderProps> = ({ isNavigationOpen = false, onToggleNavigation }) => {
+  const { siteMapNode, language } = useAppContext();
+  const location = useLocation();
+  const [internalNavigationOpen, setInternalNavigationOpen] = React.useState(false);
+
+  const navigationOpen = onToggleNavigation ? isNavigationOpen : internalNavigationOpen;
+  const toggleNavigation = onToggleNavigation || (() => setInternalNavigationOpen(!internalNavigationOpen));
+
+  const isMainPath = location.pathname === "/";
+
+  const handleLanguageChange = (newLanguage: string) => {
+    // TODO: 언어 변경 로직 구현
+    console.log("Language changed to:", newLanguage);
+  };
+
+  return (
+    <>
+      <MobileHeaderContainer isOpen={navigationOpen} isMainPath={isMainPath}>
+        <LeftContent>
+          <HamburgerButton isOpen={navigationOpen} onClick={toggleNavigation} isMainPath={isMainPath} />
+          <LogoAndTextContainer>
+            <Link to="/" style={{ textDecoration: "none" }}>
+              <Stack direction="row" alignItems="center" spacing={0.375}>
+                <Common.Components.PythonKorea style={{ width: 29, height: 29 }} />
+                <Typography
+                  variant="h6"
+                  sx={{
+                    color: isMainPath ? "white" : "rgba(18, 109, 127, 0.6)",
+                    fontSize: 18,
+                    fontWeight: 600,
+                  }}
+                >
+                  파이콘 한국 2025
+                </Typography>
+              </Stack>
+            </Link>
+          </LogoAndTextContainer>
+        </LeftContent>
+
+        <MobileLanguageToggle currentLanguage={language} onLanguageChange={handleLanguageChange} isMainPath={isMainPath} />
+      </MobileHeaderContainer>
+
+      <MobileNavigation isOpen={navigationOpen} onClose={() => toggleNavigation()} siteMapNode={siteMapNode} />
+    </>
+  );
+};
+
+const MobileHeaderContainer = styled("header")<{ isOpen: boolean; isMainPath: boolean }>(({ theme, isOpen, isMainPath }) => ({
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+
+  display: isOpen ? "none" : "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+
+  width: "100%",
+  height: 60,
+
+  padding: "15px 23px",
+
+  backgroundColor: isMainPath ? "rgba(182, 216, 215, 0.1)" : "#B6D8D7",
+  backdropFilter: "blur(8px)",
+  WebkitBackdropFilter: "blur(8px)",
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.6)",
+
+  zIndex: theme.zIndex.appBar + 100000,
+}));
+
+const LeftContent = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  gap: 17,
+});
+
+const LogoAndTextContainer = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+});

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
@@ -1,0 +1,65 @@
+import { ButtonBase, styled } from "@mui/material";
+import * as React from "react";
+
+interface MobileLanguageToggleProps {
+  currentLanguage: string;
+  onLanguageChange: (newLanguage: string) => void;
+  isMainPath?: boolean;
+}
+
+export const MobileLanguageToggle: React.FC<MobileLanguageToggleProps> = ({ currentLanguage, onLanguageChange, isMainPath = true }) => {
+  return (
+    <ToggleContainer isMainPath={isMainPath}>
+      <LanguageButton isActive={currentLanguage === "ko"} isMainPath={isMainPath} onClick={() => onLanguageChange("ko")}>
+        KO
+      </LanguageButton>
+      <LanguageButton isActive={currentLanguage === "en"} isMainPath={isMainPath} onClick={() => onLanguageChange("en")}>
+        EN
+      </LanguageButton>
+    </ToggleContainer>
+  );
+};
+
+const ToggleContainer = styled("div")<{ isMainPath: boolean }>(({ isMainPath }) => ({
+  display: "flex",
+  width: 94,
+  height: 29,
+  border: "1px solid white",
+  borderRadius: 15,
+  padding: 2,
+  gap: 2,
+  backgroundColor: isMainPath ? "transparent" : "rgba(255, 255, 255, 0.1)",
+}));
+
+const LanguageButton = styled(ButtonBase)<{ isActive: boolean; isMainPath: boolean }>(({ isActive, isMainPath }) => ({
+  flex: 1,
+  height: "100%",
+  borderRadius: 13,
+  fontSize: 12,
+  fontWeight: 400,
+  transition: "all 0.2s ease",
+
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.6)",
+  backgroundColor: "transparent",
+
+  ...(isActive && {
+    backgroundColor: isMainPath ? "rgba(255, 255, 255, 0.7)" : "rgba(255, 255, 255, 0.9)",
+    color: isMainPath ? "#888888" : "#126D7F",
+    fontWeight: 600,
+  }),
+
+  "&:hover": {
+    backgroundColor: isActive
+      ? isMainPath
+        ? "rgba(255, 255, 255, 0.8)"
+        : "rgba(255, 255, 255, 1)"
+      : isMainPath
+        ? "rgba(255, 255, 255, 0.1)"
+        : "rgba(255, 255, 255, 0.3)",
+  },
+
+  WebkitFontSmoothing: "antialiased",
+  MozOsxFontSmoothing: "grayscale",
+  textRendering: "optimizeLegibility",
+  WebkitTextStroke: "0.5px transparent",
+}));

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
@@ -27,7 +27,7 @@ export const MobileLanguageToggle: React.FC<MobileLanguageToggleProps> = ({ isMa
   );
 };
 
-const ToggleContainer = styled("div")<{ isMainPath: boolean }>(({ isMainPath }) => ({
+const ToggleContainer = styled("div")<{ isMainPath: boolean }>(({ theme, isMainPath }) => ({
   display: "flex",
   width: 94,
   height: 29,
@@ -35,10 +35,12 @@ const ToggleContainer = styled("div")<{ isMainPath: boolean }>(({ isMainPath }) 
   borderRadius: 15,
   padding: 2,
   gap: 2,
-  backgroundColor: isMainPath ? "transparent" : "rgba(255, 255, 255, 0.1)",
+  backgroundColor: isMainPath
+    ? theme.palette.mobileNavigation.main.languageToggle.background
+    : theme.palette.mobileNavigation.sub.languageToggle.background,
 }));
 
-const LanguageButton = styled(ButtonBase)<{ isActive: boolean; isMainPath: boolean }>(({ isActive, isMainPath }) => ({
+const LanguageButton = styled(ButtonBase)<{ isActive: boolean; isMainPath: boolean }>(({ theme, isActive, isMainPath }) => ({
   flex: 1,
   height: "100%",
   borderRadius: 13,
@@ -46,23 +48,25 @@ const LanguageButton = styled(ButtonBase)<{ isActive: boolean; isMainPath: boole
   fontWeight: 400,
   transition: "all 0.2s ease",
 
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.6)",
+  color: isMainPath ? theme.palette.mobileHeader.main.text : theme.palette.mobileHeader.sub.text,
   backgroundColor: "transparent",
 
   ...(isActive && {
-    backgroundColor: isMainPath ? "rgba(255, 255, 255, 0.7)" : "rgba(255, 255, 255, 0.9)",
-    color: isMainPath ? "#888888" : "#126D7F",
+    backgroundColor: isMainPath
+      ? theme.palette.mobileNavigation.main.languageToggle.active.background
+      : theme.palette.mobileNavigation.sub.languageToggle.active.background,
+    color: isMainPath ? theme.palette.mobileHeader.main.activeLanguage : theme.palette.mobileHeader.sub.activeLanguage,
     fontWeight: 600,
   }),
 
   "&:hover": {
     backgroundColor: isActive
       ? isMainPath
-        ? "rgba(255, 255, 255, 0.8)"
-        : "rgba(255, 255, 255, 1)"
+        ? theme.palette.mobileNavigation.main.languageToggle.active.hover
+        : theme.palette.mobileNavigation.sub.languageToggle.active.hover
       : isMainPath
-        ? "rgba(255, 255, 255, 0.1)"
-        : "rgba(255, 255, 255, 0.3)",
+        ? theme.palette.mobileNavigation.main.languageToggle.inactive.hover
+        : theme.palette.mobileNavigation.sub.languageToggle.inactive.hover,
   },
 
   WebkitFontSmoothing: "antialiased",

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileLanguageToggle.tsx
@@ -1,19 +1,26 @@
 import { ButtonBase, styled } from "@mui/material";
 import * as React from "react";
 
+import { LOCAL_STORAGE_LANGUAGE_KEY } from "../../../../consts/local_stroage";
+import { useAppContext } from "../../../../contexts/app_context";
+
 interface MobileLanguageToggleProps {
-  currentLanguage: string;
-  onLanguageChange: (newLanguage: string) => void;
   isMainPath?: boolean;
 }
 
-export const MobileLanguageToggle: React.FC<MobileLanguageToggleProps> = ({ currentLanguage, onLanguageChange, isMainPath = true }) => {
+export const MobileLanguageToggle: React.FC<MobileLanguageToggleProps> = ({ isMainPath = true }) => {
+  const { language, setAppContext } = useAppContext();
+
+  const handleLanguageChange = (newLanguage: "ko" | "en") => {
+    localStorage.setItem(LOCAL_STORAGE_LANGUAGE_KEY, newLanguage);
+    setAppContext((ps) => ({ ...ps, language: newLanguage }));
+  };
   return (
     <ToggleContainer isMainPath={isMainPath}>
-      <LanguageButton isActive={currentLanguage === "ko"} isMainPath={isMainPath} onClick={() => onLanguageChange("ko")}>
+      <LanguageButton isActive={language === "ko"} isMainPath={isMainPath} onClick={() => handleLanguageChange("ko")}>
         KO
       </LanguageButton>
-      <LanguageButton isActive={currentLanguage === "en"} isMainPath={isMainPath} onClick={() => onLanguageChange("en")}>
+      <LanguageButton isActive={language === "en"} isMainPath={isMainPath} onClick={() => handleLanguageChange("en")}>
         EN
       </LanguageButton>
     </ToggleContainer>

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
@@ -192,7 +192,7 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onCl
         <BottomActions isMainPath={isMainPath}>
           <Stack direction="row" alignItems="center" spacing={6.25}>
             <MobileLanguageToggle isMainPath={isMainPath} />
-            <SignInButton isMobile={true} isMainPath={isMainPath} />
+            <SignInButton isMobile={true} isMainPath={isMainPath} onClose={handleClose} />
           </Stack>
         </BottomActions>
       </DrawerContent>

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
@@ -8,7 +8,6 @@ import * as R from "remeda";
 
 import { HamburgerButton } from "./HamburgerButton";
 import { MobileLanguageToggle } from "./MobileLanguageToggle";
-import { useAppContext } from "../../../../contexts/app_context";
 import { SignInButton } from "../../SignInButton";
 
 type MenuType = BackendAPISchemas.NestedSiteMapSchema;
@@ -29,7 +28,6 @@ interface NavigationState {
 }
 
 export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onClose, siteMapNode }) => {
-  const { language } = useAppContext();
   const location = useLocation();
   const [navState, setNavState] = React.useState<NavigationState>({
     level: "depth1",
@@ -78,11 +76,6 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onCl
   const handleClose = () => {
     onClose();
     resetNavigation();
-  };
-
-  const handleLanguageChange = (newLanguage: string) => {
-    // TODO: 언어 변경 로직 구현
-    console.log("Language changed to:", newLanguage);
   };
 
   const renderDepth1Menu = () => {
@@ -198,7 +191,7 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onCl
 
         <BottomActions isMainPath={isMainPath}>
           <Stack direction="row" alignItems="center" spacing={6.25}>
-            <MobileLanguageToggle currentLanguage={language} onLanguageChange={handleLanguageChange} isMainPath={isMainPath} />
+            <MobileLanguageToggle isMainPath={isMainPath} />
             <SignInButton isMobile={true} isMainPath={isMainPath} />
           </Stack>
         </BottomActions>

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
@@ -1,0 +1,354 @@
+import * as Common from "@frontend/common";
+import BackendAPISchemas from "@frontend/common/src/schemas/backendAPI";
+import { ArrowBack, ArrowForward } from "@mui/icons-material";
+import { Box, Button, Chip, Drawer, IconButton, Stack, styled, Typography } from "@mui/material";
+import * as React from "react";
+import { Link, useLocation } from "react-router-dom";
+import * as R from "remeda";
+
+import { HamburgerButton } from "./HamburgerButton";
+import { MobileLanguageToggle } from "./MobileLanguageToggle";
+import { useAppContext } from "../../../../contexts/app_context";
+import { SignInButton } from "../../SignInButton";
+
+type MenuType = BackendAPISchemas.NestedSiteMapSchema;
+
+interface MobileNavigationProps {
+  isOpen: boolean;
+  onClose: () => void;
+  siteMapNode?: MenuType;
+}
+
+type NavigationLevel = "depth1" | "depth2" | "depth3";
+
+interface NavigationState {
+  level: NavigationLevel;
+  depth1?: MenuType;
+  depth2?: MenuType;
+  breadcrumbs: { name: string; level: NavigationLevel }[];
+}
+
+export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onClose, siteMapNode }) => {
+  const { language } = useAppContext();
+  const location = useLocation();
+  const [navState, setNavState] = React.useState<NavigationState>({
+    level: "depth1",
+    breadcrumbs: [],
+  });
+
+  const isMainPath = location.pathname === "/";
+
+  const resetNavigation = () => {
+    setNavState({
+      level: "depth1",
+      breadcrumbs: [],
+    });
+  };
+
+  const navigateToDepth2 = (depth1: MenuType) => {
+    setNavState({
+      level: "depth2",
+      depth1,
+      breadcrumbs: [{ name: depth1.name, level: "depth1" }],
+    });
+  };
+
+  const navigateToDepth3 = (depth2: MenuType) => {
+    setNavState((prev) => ({
+      ...prev,
+      level: "depth3",
+      depth2,
+      breadcrumbs: [...prev.breadcrumbs, { name: depth2.name, level: "depth2" }],
+    }));
+  };
+
+  const goBack = () => {
+    if (navState.level === "depth3") {
+      setNavState((prev) => ({
+        ...prev,
+        level: "depth2",
+        depth2: undefined,
+        breadcrumbs: prev.breadcrumbs.slice(0, -1),
+      }));
+    } else if (navState.level === "depth2") {
+      resetNavigation();
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+    resetNavigation();
+  };
+
+  const handleLanguageChange = (newLanguage: string) => {
+    // TODO: 언어 변경 로직 구현
+    console.log("Language changed to:", newLanguage);
+  };
+
+  const renderDepth1Menu = () => {
+    if (!siteMapNode) return null;
+
+    return (
+      <MenuContainer>
+        {Object.values(siteMapNode.children)
+          .filter((s) => !s.hide)
+          .map((menu) => (
+            <MenuItem isMainPath={isMainPath} key={menu.id}>
+              <MenuLink isMainPath={isMainPath} to={menu.route_code} onClick={handleClose}>
+                {menu.name}
+              </MenuLink>
+              {!R.isEmpty(menu.children) && (
+                <MenuArrowButton isMainPath={isMainPath} onClick={() => navigateToDepth2(menu)}>
+                  <ArrowForward fontSize="small" />
+                </MenuArrowButton>
+              )}
+            </MenuItem>
+          ))}
+      </MenuContainer>
+    );
+  };
+
+  const renderDepth2Menu = () => {
+    if (!navState.depth1) return null;
+
+    return (
+      <NavigationMenuSection>
+        <Depth2Header isMainPath={isMainPath}>
+          <BackButton isMainPath={isMainPath} onClick={goBack}>
+            <ArrowBack fontSize="small" />
+          </BackButton>
+          <Depth2Title isMainPath={isMainPath}>{navState.depth1.name}</Depth2Title>
+        </Depth2Header>
+
+        <Depth2Divider isMainPath={isMainPath} />
+
+        <Depth2MenuList>
+          {Object.values(navState.depth1.children)
+            .filter((s) => !s.hide)
+            .map((menu) => (
+              <Depth2MenuItem key={menu.id}>
+                <Link to={`${navState.depth1!.route_code}/${menu.route_code}`} onClick={handleClose} style={{ textDecoration: "none" }}>
+                  <MenuChip isMainPath={isMainPath} label={menu.name} clickable />
+                </Link>
+                {!R.isEmpty(menu.children) && (
+                  <MenuArrowButton isMainPath={isMainPath} onClick={() => navigateToDepth3(menu)}>
+                    <ArrowForward fontSize="small" />
+                  </MenuArrowButton>
+                )}
+              </Depth2MenuItem>
+            ))}
+        </Depth2MenuList>
+      </NavigationMenuSection>
+    );
+  };
+
+  const renderDepth3Menu = () => {
+    if (!navState.depth2) return null;
+
+    return (
+      <NavigationMenuSection>
+        <Depth2Header isMainPath={isMainPath}>
+          <BackButton isMainPath={isMainPath} onClick={goBack}>
+            <ArrowBack fontSize="small" />
+          </BackButton>
+          <Depth2Title isMainPath={isMainPath}>{navState.depth2.name}</Depth2Title>
+        </Depth2Header>
+
+        <Depth2Divider isMainPath={isMainPath} />
+
+        <Depth3MenuGrid>
+          {Object.values(navState.depth2.children)
+            .filter((s) => !s.hide)
+            .map((menu) => (
+              <Link
+                key={menu.id}
+                to={`${navState.depth1!.route_code}/${navState.depth2!.route_code}/${menu.route_code}`}
+                onClick={handleClose}
+                style={{ textDecoration: "none" }}
+              >
+                <MenuChip isMainPath={isMainPath} label={menu.name} clickable />
+              </Link>
+            ))}
+        </Depth3MenuGrid>
+      </NavigationMenuSection>
+    );
+  };
+
+  return (
+    <StyledDrawer isMainPath={isMainPath} anchor="left" open={isOpen} onClose={handleClose}>
+      <DrawerContent>
+        <NavigationHeader isMainPath={isMainPath}>
+          <HamburgerButton isOpen={true} onClick={handleClose} isMainPath={isMainPath} />
+
+          <LogoAndTextContainer>
+            <Link to="/" onClick={handleClose} style={{ textDecoration: "none" }}>
+              <Stack direction="row" alignItems="center" spacing={0.375}>
+                <Common.Components.PythonKorea style={{ width: 29, height: 29 }} />
+                <HeaderTitle isMainPath={isMainPath}>파이콘 한국 2025</HeaderTitle>
+              </Stack>
+            </Link>
+          </LogoAndTextContainer>
+        </NavigationHeader>
+
+        <NavigationContent>
+          {navState.level === "depth1" && renderDepth1Menu()}
+          {navState.level === "depth2" && renderDepth2Menu()}
+          {navState.level === "depth3" && renderDepth3Menu()}
+        </NavigationContent>
+
+        <BottomActions isMainPath={isMainPath}>
+          <Stack direction="row" alignItems="center" spacing={6.25}>
+            <MobileLanguageToggle currentLanguage={language} onLanguageChange={handleLanguageChange} isMainPath={isMainPath} />
+            <SignInButton isMobile={true} isMainPath={isMainPath} />
+          </Stack>
+        </BottomActions>
+      </DrawerContent>
+    </StyledDrawer>
+  );
+};
+
+const StyledDrawer = styled(Drawer)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+  "& .MuiDrawer-paper": {
+    width: "70vw",
+    background: isMainPath
+      ? `linear-gradient(0deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)),
+         linear-gradient(0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15))`
+      : "#B6D8D7",
+    backdropFilter: isMainPath ? "blur(10px)" : "none",
+    WebkitBackdropFilter: isMainPath ? "blur(10px)" : "none",
+    color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+    borderTopRightRadius: 15,
+    borderBottomRightRadius: 15,
+  },
+}));
+
+const DrawerContent = styled(Box)({
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+});
+
+const NavigationHeader = styled(Box)<{ isMainPath: boolean }>({
+  display: "flex",
+  alignItems: "center",
+  padding: "23px 23px 10px 23px",
+  position: "relative",
+  gap: 17,
+});
+
+const NavigationContent = styled(Box)({
+  flex: 1,
+  overflow: "auto",
+});
+
+const MenuContainer = styled(Stack)({
+  padding: "20px 0",
+  gap: "25px",
+});
+
+const MenuItem = styled(Box)<{ isMainPath?: boolean }>({
+  display: "flex",
+  alignItems: "center",
+  padding: "0 23px",
+  gap: 23,
+});
+
+const MenuLink = styled(Link)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  textDecoration: "none",
+  fontSize: "20px",
+  fontWeight: 600,
+}));
+
+const MenuArrowButton = styled(IconButton)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  padding: 8,
+}));
+
+const BackButton = styled(Button)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+  display: "flex",
+  alignItems: "center",
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  textTransform: "none",
+  padding: "0 15px 0 0",
+  minWidth: "auto",
+  minHeight: "auto",
+}));
+
+const MenuChip = styled(Chip)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+  backgroundColor: isMainPath ? "rgba(212, 212, 212, 0.5)" : "rgba(18, 109, 127, 0.2)",
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  height: 40,
+  borderRadius: 15,
+  padding: "10px 13px",
+  fontSize: "16px",
+  fontWeight: 600,
+
+  "& .MuiChip-label": {
+    padding: 0,
+  },
+
+  "&:hover": {
+    backgroundColor: isMainPath ? "rgba(212, 212, 212, 0.7)" : "rgba(18, 109, 127, 0.3)",
+  },
+}));
+
+const BottomActions = styled(Stack)<{ isMainPath: boolean }>({
+  padding: "20px 23px",
+  gap: 50,
+  alignItems: "center",
+});
+
+const HeaderTitle = styled(Typography)<{ isMainPath: boolean }>(({ theme, isMainPath }) => ({
+  color: isMainPath ? theme.palette.mobileHeader.main.text : theme.palette.mobileHeader.sub.text,
+  fontSize: 18,
+  fontWeight: 600,
+}));
+
+const LogoAndTextContainer = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+});
+
+const NavigationMenuSection = styled(Box)({
+  padding: "20px 23px",
+});
+
+const Depth2Header = styled(Box)<{ isMainPath: boolean }>({
+  display: "flex",
+  alignItems: "center",
+  height: "auto",
+  marginBottom: 10,
+});
+
+const Depth2Title = styled(Typography)<{ isMainPath: boolean }>(({ isMainPath }) => ({
+  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  fontSize: 20,
+  fontWeight: 800,
+}));
+
+const Depth2Divider = styled(Box)<{ isMainPath: boolean }>(({ isMainPath }) => ({
+  height: 1,
+  backgroundColor: isMainPath ? "rgba(255, 255, 255, 0.3)" : "rgba(18, 109, 127, 0.3)",
+  marginBottom: 21,
+}));
+
+const Depth2MenuList = styled(Stack)({
+  gap: 15,
+});
+
+const Depth2MenuItem = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+});
+
+const Depth3MenuGrid = styled(Box)({
+  height: 260,
+  display: "flex",
+  flexDirection: "column",
+  flexWrap: "wrap",
+  alignContent: "flex-start",
+  gap: 15,
+  overflow: "hidden",
+});

--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
@@ -200,16 +200,13 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onCl
   );
 };
 
-const StyledDrawer = styled(Drawer)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+const StyledDrawer = styled(Drawer)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
   "& .MuiDrawer-paper": {
     width: "70vw",
-    background: isMainPath
-      ? `linear-gradient(0deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)),
-         linear-gradient(0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15))`
-      : "#B6D8D7",
+    background: isMainPath ? theme.palette.mobileNavigation.main.background : theme.palette.mobileNavigation.sub.background,
     backdropFilter: isMainPath ? "blur(10px)" : "none",
     WebkitBackdropFilter: isMainPath ? "blur(10px)" : "none",
-    color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+    color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
     borderTopRightRadius: 15,
     borderBottomRightRadius: 15,
   },
@@ -246,31 +243,31 @@ const MenuItem = styled(Box)<{ isMainPath?: boolean }>({
   gap: 23,
 });
 
-const MenuLink = styled(Link)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+const MenuLink = styled(Link)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
   textDecoration: "none",
   fontSize: "20px",
   fontWeight: 600,
 }));
 
-const MenuArrowButton = styled(IconButton)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+const MenuArrowButton = styled(IconButton)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
   padding: 8,
 }));
 
-const BackButton = styled(Button)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
+const BackButton = styled(Button)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
   display: "flex",
   alignItems: "center",
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
   textTransform: "none",
   padding: "0 15px 0 0",
   minWidth: "auto",
   minHeight: "auto",
 }));
 
-const MenuChip = styled(Chip)<{ isMainPath?: boolean }>(({ isMainPath = true }) => ({
-  backgroundColor: isMainPath ? "rgba(212, 212, 212, 0.5)" : "rgba(18, 109, 127, 0.2)",
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+const MenuChip = styled(Chip)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
+  backgroundColor: isMainPath ? theme.palette.mobileNavigation.main.chip.background : theme.palette.mobileNavigation.sub.chip.background,
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
   height: 40,
   borderRadius: 15,
   padding: "10px 13px",
@@ -282,7 +279,7 @@ const MenuChip = styled(Chip)<{ isMainPath?: boolean }>(({ isMainPath = true }) 
   },
 
   "&:hover": {
-    backgroundColor: isMainPath ? "rgba(212, 212, 212, 0.7)" : "rgba(18, 109, 127, 0.3)",
+    backgroundColor: isMainPath ? theme.palette.mobileNavigation.main.chip.hover : theme.palette.mobileNavigation.sub.chip.hover,
   },
 }));
 
@@ -314,15 +311,15 @@ const Depth2Header = styled(Box)<{ isMainPath: boolean }>({
   marginBottom: 10,
 });
 
-const Depth2Title = styled(Typography)<{ isMainPath: boolean }>(({ isMainPath }) => ({
-  color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+const Depth2Title = styled(Typography)<{ isMainPath: boolean }>(({ theme, isMainPath }) => ({
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
   fontSize: 20,
   fontWeight: 800,
 }));
 
-const Depth2Divider = styled(Box)<{ isMainPath: boolean }>(({ isMainPath }) => ({
+const Depth2Divider = styled(Box)<{ isMainPath: boolean }>(({ theme, isMainPath }) => ({
   height: 1,
-  backgroundColor: isMainPath ? "rgba(255, 255, 255, 0.3)" : "rgba(18, 109, 127, 0.3)",
+  backgroundColor: isMainPath ? theme.palette.mobileNavigation.main.divider : theme.palette.mobileNavigation.sub.divider,
   marginBottom: 21,
 }));
 

--- a/apps/pyconkr/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr/src/components/layout/Header/index.tsx
@@ -1,6 +1,6 @@
 import * as Common from "@frontend/common";
 import { ArrowForwardIos } from "@mui/icons-material";
-import { Box, Button, CircularProgress, Divider, Stack, styled, SxProps, Theme, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Divider, Stack, styled, SxProps, Theme, Typography, useMediaQuery, useTheme } from "@mui/material";
 import { MUIStyledCommonProps } from "@mui/system";
 import * as React from "react";
 import { Link } from "react-router-dom";
@@ -11,6 +11,7 @@ import { useAppContext } from "../../../contexts/app_context";
 import { CartBadgeButton } from "../CartBadgeButton";
 import LanguageSelector from "../LanguageSelector";
 import { SignInButton } from "../SignInButton";
+import { MobileHeader } from "./Mobile/MobileHeader";
 
 type MenuType = BackendAPISchemas.NestedSiteMapSchema;
 type MenuOrUndefinedType = MenuType | undefined;
@@ -26,6 +27,8 @@ const BreadCrumbHeight: React.CSSProperties["height"] = "4.5rem";
 
 const Header: React.FC = () => {
   const { title, language, siteMapNode, currentSiteMapDepth, shouldShowTitleBanner } = useAppContext();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [navState, setNavState] = React.useState<NavigationStateType>({});
 
   const resetDepths = () => setNavState({});
@@ -37,6 +40,10 @@ const Header: React.FC = () => {
   const getDepth3Route = (nextRoute?: string) => getDepth2Route(navState.depth2?.route_code) + `/${nextRoute || ""}`;
 
   React.useEffect(resetDepths, [language]);
+
+  if (isMobile) {
+    return <MobileHeader />;
+  }
 
   let breadCrumbRoute = "";
   let breadCrumbArray = currentSiteMapDepth.slice(1, -1);

--- a/apps/pyconkr/src/components/layout/SignInButton/index.tsx
+++ b/apps/pyconkr/src/components/layout/SignInButton/index.tsx
@@ -1,5 +1,6 @@
 import * as Shop from "@frontend/shop";
-import { Button } from "@mui/material";
+import { Login } from "@mui/icons-material";
+import { Button, Stack } from "@mui/material";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import { useNavigate } from "react-router-dom";
 
@@ -9,14 +10,44 @@ type InnerSignInButtonImplPropType = {
   loading?: boolean;
   signedIn?: boolean;
   onSignOut?: () => void;
+  isMobile?: boolean;
+  isMainPath?: boolean;
 };
 
-const InnerSignInButtonImpl: React.FC<InnerSignInButtonImplPropType> = ({ loading, signedIn, onSignOut }) => {
+const InnerSignInButtonImpl: React.FC<InnerSignInButtonImplPropType> = ({ loading, signedIn, onSignOut, isMobile = false, isMainPath = true }) => {
   const navigate = useNavigate();
   const { language } = useAppContext();
 
   const signInBtnStr = language === "ko" ? "로그인" : "Sign In";
   const signOutBtnStr = language === "ko" ? "로그아웃" : "Sign Out";
+
+  if (isMobile) {
+    return (
+      <Button
+        variant="text"
+        sx={{
+          color: isMainPath ? "white" : "rgba(18, 109, 127, 0.9)",
+          height: 29,
+          fontSize: 13,
+          fontWeight: 500,
+          textTransform: "none",
+          minWidth: "auto",
+          padding: "0 13px",
+
+          "&:hover": {
+            backgroundColor: isMainPath ? "rgba(255, 255, 255, 0.1)" : "rgba(18, 109, 127, 0.1)",
+          },
+        }}
+        loading={loading}
+        onClick={() => (signedIn ? onSignOut?.() : navigate("/account/sign-in"))}
+      >
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Login fontSize="small" />
+          {signedIn ? signOutBtnStr : signInBtnStr}
+        </Stack>
+      </Button>
+    );
+  }
 
   return (
     <Button
@@ -29,13 +60,17 @@ const InnerSignInButtonImpl: React.FC<InnerSignInButtonImplPropType> = ({ loadin
   );
 };
 
-export const SignInButton: React.FC = ErrorBoundary.with(
-  { fallback: <InnerSignInButtonImpl /> },
-  Suspense.with({ fallback: <InnerSignInButtonImpl loading /> }, () => {
-    const shopAPIClient = Shop.Hooks.useShopClient();
-    const signOutMutation = Shop.Hooks.useSignOutMutation(shopAPIClient);
-    const { data } = Shop.Hooks.useUserStatus(shopAPIClient);
+export const SignInButton: React.FC<{ isMobile?: boolean; isMainPath?: boolean }> = ({ isMobile = false, isMainPath = true }) => {
+  const SignInWithErrorBoundary = ErrorBoundary.with(
+    { fallback: <InnerSignInButtonImpl isMobile={isMobile} isMainPath={isMainPath} /> },
+    Suspense.with({ fallback: <InnerSignInButtonImpl loading isMobile={isMobile} isMainPath={isMainPath} /> }, () => {
+      const shopAPIClient = Shop.Hooks.useShopClient();
+      const signOutMutation = Shop.Hooks.useSignOutMutation(shopAPIClient);
+      const { data } = Shop.Hooks.useUserStatus(shopAPIClient);
 
-    return <InnerSignInButtonImpl signedIn={data !== null} onSignOut={signOutMutation.mutate} />;
-  })
-);
+      return <InnerSignInButtonImpl signedIn={data !== null} onSignOut={signOutMutation.mutate} isMobile={isMobile} isMainPath={isMainPath} />;
+    })
+  );
+
+  return <SignInWithErrorBoundary />;
+};

--- a/apps/pyconkr/src/styles/globalStyles.ts
+++ b/apps/pyconkr/src/styles/globalStyles.ts
@@ -36,6 +36,47 @@ export const muiTheme = createTheme({
         activeLanguage: "#126D7F",
       },
     },
+    mobileNavigation: {
+      main: {
+        background:
+          "linear-gradient(0deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)), linear-gradient(0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15))",
+        text: "#FFFFFF",
+        chip: {
+          background: "rgba(212, 212, 212, 0.5)",
+          hover: "rgba(212, 212, 212, 0.7)",
+        },
+        divider: "rgba(255, 255, 255, 0.3)",
+        languageToggle: {
+          background: "transparent",
+          active: {
+            background: "rgba(255, 255, 255, 0.7)",
+            hover: "rgba(255, 255, 255, 0.8)",
+          },
+          inactive: {
+            hover: "rgba(255, 255, 255, 0.1)",
+          },
+        },
+      },
+      sub: {
+        background: "#B6D8D7",
+        text: "rgba(18, 109, 127, 0.9)",
+        chip: {
+          background: "rgba(18, 109, 127, 0.2)",
+          hover: "rgba(18, 109, 127, 0.3)",
+        },
+        divider: "rgba(18, 109, 127, 0.3)",
+        languageToggle: {
+          background: "rgba(255, 255, 255, 0.1)",
+          active: {
+            background: "rgba(255, 255, 255, 0.9)",
+            hover: "rgba(255, 255, 255, 1)",
+          },
+          inactive: {
+            hover: "rgba(255, 255, 255, 0.3)",
+          },
+        },
+      },
+    },
     text: {
       primary: "#000000",
       secondary: "#666666",

--- a/apps/pyconkr/src/styles/globalStyles.ts
+++ b/apps/pyconkr/src/styles/globalStyles.ts
@@ -24,6 +24,18 @@ export const muiTheme = createTheme({
       dark: "#C66900",
       contrastText: "#FFFFFF",
     },
+    mobileHeader: {
+      main: {
+        background: "rgba(182, 216, 215, 0.1)",
+        text: "#FFFFFF",
+        activeLanguage: "#888888",
+      },
+      sub: {
+        background: "#B6D8D7",
+        text: "rgba(18, 109, 127, 0.6)",
+        activeLanguage: "#126D7F",
+      },
+    },
     text: {
       primary: "#000000",
       secondary: "#666666",

--- a/types/emotion.d.ts
+++ b/types/emotion.d.ts
@@ -16,6 +16,46 @@ declare module "@mui/material/styles" {
         activeLanguage: string;
       };
     };
+    mobileNavigation: {
+      main: {
+        background: string;
+        text: string;
+        chip: {
+          background: string;
+          hover: string;
+        };
+        divider: string;
+        languageToggle: {
+          background: string;
+          active: {
+            background: string;
+            hover: string;
+          };
+          inactive: {
+            hover: string;
+          };
+        };
+      };
+      sub: {
+        background: string;
+        text: string;
+        chip: {
+          background: string;
+          hover: string;
+        };
+        divider: string;
+        languageToggle: {
+          background: string;
+          active: {
+            background: string;
+            hover: string;
+          };
+          inactive: {
+            hover: string;
+          };
+        };
+      };
+    };
   }
 
   interface PaletteOptions {
@@ -30,6 +70,46 @@ declare module "@mui/material/styles" {
         background: string;
         text: string;
         activeLanguage: string;
+      };
+    };
+    mobileNavigation?: {
+      main: {
+        background: string;
+        text: string;
+        chip: {
+          background: string;
+          hover: string;
+        };
+        divider: string;
+        languageToggle: {
+          background: string;
+          active: {
+            background: string;
+            hover: string;
+          };
+          inactive: {
+            hover: string;
+          };
+        };
+      };
+      sub: {
+        background: string;
+        text: string;
+        chip: {
+          background: string;
+          hover: string;
+        };
+        divider: string;
+        languageToggle: {
+          background: string;
+          active: {
+            background: string;
+            hover: string;
+          };
+          inactive: {
+            hover: string;
+          };
+        };
       };
     };
   }

--- a/types/emotion.d.ts
+++ b/types/emotion.d.ts
@@ -4,10 +4,34 @@ import { type Theme as MuiTheme } from "@mui/material/styles";
 declare module "@mui/material/styles" {
   interface Palette {
     highlight: PaletteColor;
+    mobileHeader: {
+      main: {
+        background: string;
+        text: string;
+        activeLanguage: string;
+      };
+      sub: {
+        background: string;
+        text: string;
+        activeLanguage: string;
+      };
+    };
   }
 
   interface PaletteOptions {
     highlight: PaletteColor;
+    mobileHeader?: {
+      main: {
+        background: string;
+        text: string;
+        activeLanguage: string;
+      };
+      sub: {
+        background: string;
+        text: string;
+        activeLanguage: string;
+      };
+    };
   }
 
   interface PaletteColor {


### PR DESCRIPTION
### 작업 내용
- 모바일 GNB UI를 구현했습니다.
- 라우트 별로 색상 및 UI 다르게 표현 (메인 화면, 이외 화면 구분)


#### 추가한 파일 구조
```
Header/Mobile/
├── MobileHeader.tsx          # 모바일 헤더 컨테이너
├── MobileNavigation.tsx      # 3단계 네비게이션 드로어
├── MobileLanguageToggle.tsx  # 언어 토글 컴포넌트
└── HamburgerButton.tsx       # 햄버거 메뉴 버튼
```


### 고민 및 공유할 내용
#### 🤔 메인 화면과 이외 화면의 색상이 다른 것
 - 피그마에 메인화면이 아닌 경우에는 색상이 다르게 되어있어, 색상이 다르게 구현을 했습니다. 다만, 펼쳐졌을때의 디자인이 없어서
   - 메인 화면 : 투명한 헤더 , 블러처리 된 배경 
   - 이외 화면 : 메인 색상인 초록색 배경 -> 투명한 배경으로 하니 글자가 많은 화면에서는 흰색 네비게이션 글자가 잘 안보이길래 추가했습니닷,,,🫣
   아래 사진같이 구현을 했는데, 혹시 디자인 의도와 다른 구현일 수 도 있을 것 같아서,,확인 부탁드립니다!
<img width="288" alt="image" src="https://github.com/user-attachments/assets/0b371176-ea38-42b2-bab8-02e9bce8bb90" />
<img width="282" alt="image" src="https://github.com/user-attachments/assets/42a0071e-6094-414f-a895-05ebbaaba9fe" />

#### 🤔 2번째 뎁스에 화살표가 없는 것
- 피그마 상에는 2번째 뎁스 메뉴의 경우에 3번째 뎁스로 가는 화살표가 없습니다. 하지만 사용자에게 3번째 뎁스가 있음을 알려주는 것이 사용자가 인지하기에 쉽다고(?) 생각해서 추가를 헀습니다. 하지만 이것도 저의 임의로 추가를 한거라서 디자인팀에 확인이 한 번 더 필요할 것 같습니다..!

[ (좌측) 개발 화면, (우측) 피그마 디자인 ]
<img width="266" alt="image" src="https://github.com/user-attachments/assets/04af4e91-fb72-4b82-b4a5-c849a616e1b2" /><img width="282" alt="image" src="https://github.com/user-attachments/assets/1c752a6a-19bc-430c-b1cb-396a35df944c" />

#### 🤔 마이페이지 화면
- 피그마 상에서는 로그인 성공을 하게 되면 모바일 UI 하단의 "로그인"이 "마이페이지"로 변경되어있습니다. 하지만 데스크탑 기준 마이페이지가 없는 것으로 보여 로그아웃으로 구현을 했습니다. 혹시 마이페이지가 따로 있다면 다시 변경하겠습니다.



수정해야하는 부분 알려주시면 바로 수정하겠습니다!

