### PR TITLE
feat : navigation UX 개선

### DIFF
--- a/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
+++ b/apps/pyconkr/src/components/layout/Header/Mobile/MobileNavigation.tsx
@@ -87,9 +87,15 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ isOpen, onCl
           .filter((s) => !s.hide)
           .map((menu) => (
             <MenuItem isMainPath={isMainPath} key={menu.id}>
-              <MenuLink isMainPath={isMainPath} to={menu.route_code} onClick={handleClose}>
-                {menu.name}
-              </MenuLink>
+              {!R.isEmpty(menu.children) && Object.values(menu.children).some((child) => !child.hide) ? (
+                <MenuButton isMainPath={isMainPath} onClick={() => navigateToDepth2(menu)}>
+                  {menu.name}
+                </MenuButton>
+              ) : (
+                <MenuLink isMainPath={isMainPath} to={menu.route_code} onClick={handleClose}>
+                  {menu.name}
+                </MenuLink>
+              )}
               {!R.isEmpty(menu.children) && Object.values(menu.children).some((child) => !child.hide) && (
                 <MenuArrowButton isMainPath={isMainPath} onClick={() => navigateToDepth2(menu)}>
                   <ArrowForward fontSize="small" />
@@ -248,6 +254,17 @@ const MenuLink = styled(Link)<{ isMainPath?: boolean }>(({ theme, isMainPath = t
   textDecoration: "none",
   fontSize: "20px",
   fontWeight: 600,
+}));
+
+const MenuButton = styled(Button)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({
+  color: isMainPath ? theme.palette.mobileNavigation.main.text : theme.palette.mobileNavigation.sub.text,
+  textTransform: "none",
+  fontSize: "20px",
+  fontWeight: 600,
+  padding: 0,
+  minWidth: "auto",
+  minHeight: "auto",
+  justifyContent: "flex-start",
 }));
 
 const MenuArrowButton = styled(IconButton)<{ isMainPath?: boolean }>(({ theme, isMainPath = true }) => ({


### PR DESCRIPTION
## PR 개요
- 디자인 팀에서 요청해주신 모바일 네비게이션 UX를 개선했습니다.

## 작업 내용
**1. 하위 메뉴 화살표 표시 로직 수정**
"후원하기" 메뉴의 하위에 "후원사" 메뉴가 있지만 `hide: true`인 경우 화살표가 표시되지 않았습니다.
- `hide: false`인 하위 메뉴가 하나라도 있을 때만 화살표 표시하도록 변경했습니다.


**2. 메뉴 클릭 동작 개선**
(디자인 팀 요청) 하위메뉴가 있는 경우 제목을 클릭하면 하위메뉴가 보이도록 수정했습니다.
- 하위 메뉴가 있는 경우: 제목 클릭 시 하위 메뉴로 이동 (화살표와 동일한 동작)
- 하위 메뉴가 없는 경우: 제목 클릭 시 해당 페이지로 바로 이동
