### PR TITLE
feat: CMS year filter 추가

### DIFF
--- a/apps/pyconkr-admin/src/components/pages/sitemap/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/sitemap/list.tsx
@@ -11,9 +11,12 @@ import {
   DialogTitle,
   IconButton,
   IconButtonProps,
+  MenuItem,
+  Select,
   Stack,
   styled,
   Tooltip,
+  Typography,
 } from "@mui/material";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import { enqueueSnackbar, OptionsObject } from "notistack";
@@ -94,17 +97,18 @@ type InnerSiteMapStateType = {
 
 const ModifyDetectionFields: (keyof FlatSiteMap)[] = ["order", "parent_sitemap"];
 
-const InnerSiteMapList: React.FC = ErrorBoundary.with(
+const InnerSiteMapList: React.FC<{ year: number }> = ErrorBoundary.with(
   { fallback: ErrorFallback },
-  Suspense.with({ fallback: <CircularProgress /> }, () => {
+  Suspense.with({ fallback: <CircularProgress /> }, ({ year }: { year: number }) => {
     const backendAdminAPIClient = useBackendAdminClient();
-    const { data } = useListQuery<FlatSiteMap>(backendAdminAPIClient, "cms", "sitemap");
-    const originalFlatSiteMapObj = Object.values(data).reduce((acc, item) => ({ ...acc, [item.id]: item }), {} as FlatSiteMapObj);
+    const { data } = useListQuery<FlatSiteMap>(backendAdminAPIClient, "cms", "sitemap", { year: String(year) });
     const deleteMutation = useRemovePreparedMutation(backendAdminAPIClient, "cms", "sitemap");
     const { mutateAsync: updateMutationAsync } = useUpdatePreparedMutation(backendAdminAPIClient, "cms", "sitemap");
 
     const addSnackbar = (c: string | React.ReactNode, variant: OptionsObject["variant"]) =>
       enqueueSnackbar(c, { variant, anchorOrigin: { vertical: "bottom", horizontal: "center" } });
+
+    const originalFlatSiteMapObj = Object.values(data).reduce((acc, item) => ({ ...acc, [item.id]: item }), {} as FlatSiteMapObj);
 
     const [state, setState] = React.useState<InnerSiteMapStateType>({ flatSiteMap: data });
     const nestedSiteMap = buildNestedSiteMap<FlatSiteMap>(state.flatSiteMap)[""];
@@ -241,8 +245,29 @@ const InnerSiteMapList: React.FC = ErrorBoundary.with(
   })
 );
 
-export const SiteMapList: React.FC = () => (
-  <BackendAdminSignInGuard>
-    <InnerSiteMapList />
-  </BackendAdminSignInGuard>
-);
+const YEAR_OPTIONS = [2025, 2026];
+
+export const SiteMapList: React.FC = () => {
+  const [year, setYear] = React.useState(new Date().getFullYear());
+
+  return (
+    <BackendAdminSignInGuard>
+      <Stack spacing={2} sx={{ width: "100%", height: "100%" }}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="body2" fontWeight="bold">연도</Typography>
+          <Select
+            size="small"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            sx={{ width: 100 }}
+          >
+            {YEAR_OPTIONS.map((y) => (
+              <MenuItem key={y} value={y}>{y}</MenuItem>
+            ))}
+          </Select>
+        </Stack>
+        <InnerSiteMapList year={year} />
+      </Stack>
+    </BackendAdminSignInGuard>
+  );
+};

--- a/packages/common/src/schemas/backendAdminAPI.ts
+++ b/packages/common/src/schemas/backendAdminAPI.ts
@@ -63,6 +63,7 @@ export type PageSectionSchema = {
 
 export type FlattenedSiteMapSchema = {
   id: string;
+  year: number;
   route_code: string;
   name_ko: string;
   name_en: string;
@@ -75,6 +76,7 @@ export type FlattenedSiteMapSchema = {
 
 export type NestedSiteMapSchema = {
   id: string;
+  year: number;
   route_code: string;
   name_ko: string;
   name_en: string;


### PR DESCRIPTION
- [x] CMS 어드민 페이지에서 사이트맵 상단에 year 필터를 추가했습니다. (현재는 2025, 2026년만 보이도록 설정했습니다)

- 해당 코드는 백엔드 API에서 `/v1/admin-api/cms/sitemap/?year=2025` 같은 식으로 query param을 보내는 것을 가정하고 작업했는데요. 추후 작업하실 때 방향이 바뀐다면 해당 코드도 수정하겠습니다:)

- 실제로 나오는 모습은 하단 화면 캡처를 참고해주심 감사하겠습니다!
<img width="637" height="659" alt="스크린샷 2026-05-07 오전 12 50 54" src="https://github.com/user-attachments/assets/2b8f8bfa-fd43-47a8-a93f-0337d446b0e9" />
