### PR TITLE
feat: 스토어 어드민 페이지 추가 (태그/카테고리/상품/주문)

### DIFF
--- a/apps/pyconkr-admin/src/components/elements/admin_filter_fieldset.tsx
+++ b/apps/pyconkr-admin/src/components/elements/admin_filter_fieldset.tsx
@@ -1,0 +1,32 @@
+import { Stack, styled } from "@mui/material";
+import * as React from "react";
+
+const StyledFieldset = styled("fieldset")(({ theme }) => ({
+  margin: 0,
+  padding: theme.spacing(1, 2, 2),
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+  minWidth: 0,
+  width: "fit-content",
+  maxWidth: "100%",
+}));
+
+const StyledLegend = styled("legend")(({ theme }) => ({
+  padding: theme.spacing(0, 1),
+  color: theme.palette.text.secondary,
+  ...theme.typography.caption,
+}));
+
+type Props = {
+  label: string;
+  children: React.ReactNode;
+};
+
+export const AdminFilterFieldset: React.FC<Props> = ({ label, children }) => (
+  <StyledFieldset>
+    <StyledLegend>{label}</StyledLegend>
+    <Stack direction="row" spacing={2} flexWrap="wrap" alignItems="center" sx={{ rowGap: 2 }}>
+      {children}
+    </Stack>
+  </StyledFieldset>
+);

--- a/apps/pyconkr-admin/src/components/elements/admin_pagination.tsx
+++ b/apps/pyconkr-admin/src/components/elements/admin_pagination.tsx
@@ -1,0 +1,68 @@
+import { FormControl, InputLabel, MenuItem, Pagination, Select, Stack, Typography } from "@mui/material";
+import * as React from "react";
+
+type Props = {
+  count: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  pageSizeOptions?: number[];
+  scrollToTopOnChange?: boolean;
+};
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
+
+const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
+
+export const AdminPagination: React.FC<Props> = ({
+  count,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  scrollToTopOnChange = true,
+}) => {
+  const pageCount = Math.max(1, Math.ceil(count / pageSize));
+  const startIdx = count === 0 ? 0 : (page - 1) * pageSize + 1;
+  const endIdx = Math.min(page * pageSize, count);
+
+  const handlePageChange = (newPage: number) => {
+    onPageChange(newPage);
+    if (scrollToTopOnChange) scrollToTop();
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    onPageSizeChange(newSize);
+    if (scrollToTopOnChange) scrollToTop();
+  };
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between" sx={{ flexWrap: "wrap", py: 1 }}>
+      <Typography variant="body2" color="text.secondary">
+        {count.toLocaleString()}건 중 {startIdx.toLocaleString()}–{endIdx.toLocaleString()}
+      </Typography>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <Pagination
+          count={pageCount}
+          page={Math.min(page, pageCount)}
+          onChange={(_, p) => handlePageChange(p)}
+          showFirstButton
+          showLastButton
+          size="small"
+        />
+        <FormControl size="small" sx={{ minWidth: 110 }}>
+          <InputLabel id="admin-page-size-label">페이지당</InputLabel>
+          <Select labelId="admin-page-size-label" label="페이지당" value={pageSize} onChange={(e) => handlePageSizeChange(Number(e.target.value))}>
+            {pageSizeOptions.map((size) => (
+              <MenuItem key={size} value={size}>
+                {size}개
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/pyconkr-admin/src/components/elements/public_file_picker.tsx
+++ b/apps/pyconkr-admin/src/components/elements/public_file_picker.tsx
@@ -1,0 +1,119 @@
+import { useBackendAdminClient, useChoicesQuery, usePublicFileQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { OpenInNew } from "@mui/icons-material";
+import { Autocomplete, Box, Button, CircularProgress, Stack, TextField } from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import * as React from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+type Option = { value: string; label: string };
+
+type Props = {
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  // choices를 가져올 위치 (RJSF choices endpoint 활용)
+  choicesApp: string;
+  choicesResource: string;
+  choicesField: string;
+  // 확장자 화이트리스트 (대소문자 무시, 점 prefix 없이). 미지정 시 모든 파일 노출.
+  acceptExtensions?: string[];
+};
+
+const PREVIEW_SIZE = 56;
+
+const previewBoxSx = {
+  width: PREVIEW_SIZE,
+  height: PREVIEW_SIZE,
+  flexShrink: 0,
+  border: 1,
+  borderColor: "divider",
+  borderRadius: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  bgcolor: "action.hover",
+  overflow: "hidden",
+};
+
+const ImagePreview: React.FC<{ id: string }> = ErrorBoundary.with(
+  { fallback: () => <Box sx={previewBoxSx} /> },
+  Suspense.with(
+    {
+      fallback: (
+        <Box sx={previewBoxSx}>
+          <CircularProgress size={20} />
+        </Box>
+      ),
+    },
+    ({ id }) => {
+      const client = useBackendAdminClient();
+      const { data } = usePublicFileQuery(client, id);
+      if (!data) return <Box sx={previewBoxSx} />;
+      const isImage = data.mimetype?.startsWith("image/");
+      if (!isImage) {
+        return (
+          <Box
+            component="a"
+            href={data.file}
+            target="_blank"
+            rel="noopener"
+            sx={{ ...previewBoxSx, fontSize: 11, textDecoration: "none", color: "text.secondary" }}
+          >
+            파일
+          </Box>
+        );
+      }
+      return (
+        <Box component="a" href={data.file} target="_blank" rel="noopener" sx={previewBoxSx} title="원본 보기">
+          <Box component="img" src={data.file} alt="" sx={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }} />
+        </Box>
+      );
+    }
+  )
+);
+
+export const PublicFilePicker: React.FC<Props> = ({
+  label = "이미지",
+  value,
+  onChange,
+  choicesApp,
+  choicesResource,
+  choicesField,
+  acceptExtensions,
+}) => {
+  const client = useBackendAdminClient();
+  const choicesQuery = useChoicesQuery(client, choicesApp, choicesResource);
+  const options: Option[] = React.useMemo(() => {
+    const all = (choicesQuery.data?.[choicesField] ?? []).map((item) => ({ value: item.const ?? "", label: item.title }));
+    if (!acceptExtensions || acceptExtensions.length === 0) return all;
+    const allowed = acceptExtensions.map((e) => e.toLowerCase());
+    return all.filter((opt) => allowed.some((ext) => opt.label.toLowerCase().endsWith(`.${ext}`)));
+  }, [choicesQuery.data, choicesField, acceptExtensions]);
+  const selected = options.find((o) => o.value === value) ?? null;
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center">
+      {value ? <ImagePreview id={value} /> : <Box sx={previewBoxSx} />}
+      <Autocomplete
+        options={options}
+        value={selected}
+        onChange={(_, newValue) => onChange(newValue?.value ?? "")}
+        getOptionLabel={(o) => o.label}
+        isOptionEqualToValue={(a, b) => a.value === b.value}
+        sx={{ flexGrow: 1, minWidth: 240 }}
+        renderInput={(params) => <TextField {...params} label={label} placeholder="파일을 선택하세요" />}
+      />
+      <Button
+        component={RouterLink}
+        to="/file/publicfile/create"
+        target="_blank"
+        variant="outlined"
+        size="small"
+        startIcon={<OpenInNew />}
+        sx={{ flexShrink: 0 }}
+      >
+        새 파일 업로드
+      </Button>
+    </Stack>
+  );
+};

--- a/apps/pyconkr-admin/src/components/layouts/admin_list.tsx
+++ b/apps/pyconkr-admin/src/components/layouts/admin_list.tsx
@@ -1,22 +1,21 @@
-import { useBackendAdminClient, useChoicesQuery, useListQuery, useOpenApiSchemaQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import {
+  useBackendAdminClient,
+  useChoicesQuery,
+  useListQuery,
+  useOpenApiSchemaQuery,
+  useRemovePreparedMutation,
+} from "@frontend/common/src/hooks/useAdminAPI";
 import { extractQueryParameters } from "@frontend/common/src/utils";
-import { Add } from "@mui/icons-material";
-import { Box, Button, CircularProgress, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import { Add, Delete, Edit } from "@mui/icons-material";
+import { Box, Button, CircularProgress, IconButton, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import * as React from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
+import { addErrorSnackbar, addSnackbar } from "../../utils/snackbar";
 import { AdminListFilter } from "../elements/admin_list_filter";
 import { BackendAdminSignInGuard } from "../elements/admin_signin_guard";
 import { ErrorFallback } from "../elements/error_fallback";
-
-type AdminListProps = {
-  app: string;
-  resource: string;
-  hideCreatedAt?: boolean;
-  hideUpdatedAt?: boolean;
-  hideCreateNew?: boolean;
-};
 
 type ListRowType = {
   id: string;
@@ -25,68 +24,158 @@ type ListRowType = {
   updated_at: string;
 };
 
+export type AdminListColumn = {
+  field: string;
+  header: string;
+  width?: string | number;
+  align?: "left" | "right" | "center";
+  render?: (row: Record<string, unknown>) => React.ReactNode;
+};
+
+type AdminListProps = {
+  app: string;
+  resource: string;
+  title?: string;
+  hideCreatedAt?: boolean;
+  hideUpdatedAt?: boolean;
+  hideCreateNew?: boolean;
+  columns?: AdminListColumn[];
+  enableRowActions?: boolean;
+};
+
 const InnerAdminList: React.FC<AdminListProps> = ErrorBoundary.with(
   { fallback: ErrorFallback },
-  Suspense.with({ fallback: <CircularProgress /> }, ({ app, resource, hideCreatedAt, hideUpdatedAt, hideCreateNew }) => {
-    const navigate = useNavigate();
+  Suspense.with(
+    { fallback: <CircularProgress /> },
+    ({ app, resource, title, hideCreatedAt, hideUpdatedAt, hideCreateNew, columns, enableRowActions }) => {
+      const navigate = useNavigate();
 
-    const [searchParams, setSearchParams] = useSearchParams();
-    const backendAdminClient = useBackendAdminClient();
+      const [searchParams, setSearchParams] = useSearchParams();
+      const backendAdminClient = useBackendAdminClient();
 
-    const filterParams: Record<string, string> = Object.fromEntries(searchParams.entries());
-    const listQuery = useListQuery<ListRowType>(backendAdminClient, app, resource, filterParams);
+      const filterParams: Record<string, string> = Object.fromEntries(searchParams.entries());
+      const listQuery = useListQuery<ListRowType & Record<string, unknown>>(backendAdminClient, app, resource, filterParams);
 
-    const openApiSchemaQuery = useOpenApiSchemaQuery(backendAdminClient);
-    const queryParameters = React.useMemo(
-      () => extractQueryParameters(openApiSchemaQuery.data, app, resource),
-      [openApiSchemaQuery.data, app, resource]
-    );
+      const openApiSchemaQuery = useOpenApiSchemaQuery(backendAdminClient);
+      const queryParameters = React.useMemo(
+        () => extractQueryParameters(openApiSchemaQuery.data, app, resource),
+        [openApiSchemaQuery.data, app, resource]
+      );
 
-    const choicesQuery = useChoicesQuery(backendAdminClient, app, resource);
+      const choicesQuery = useChoicesQuery(backendAdminClient, app, resource);
 
-    const handleFilterApply = (newParams: Record<string, string>) => setSearchParams(newParams, { replace: true });
+      const removeMutation = useRemovePreparedMutation(backendAdminClient, app, resource);
 
-    return (
-      <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }}>
-        <Typography variant="h5">
-          {app.toUpperCase()} &gt; {resource.toUpperCase()} &gt; 목록
-        </Typography>
-        <br />
-        <AdminListFilter parameters={queryParameters} values={filterParams} choices={choicesQuery.data} onApply={handleFilterApply} />
-        <Box>
-          {!hideCreateNew && (
-            <Button variant="contained" onClick={() => navigate(`/${app}/${resource}/create`)} startIcon={<Add />}>
-              새 객체 추가
-            </Button>
-          )}
-        </Box>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ width: "25%" }}>ID</TableCell>
-              <TableCell sx={{ width: "40%" }}>이름</TableCell>
-              {hideCreatedAt === true && <TableCell sx={{ width: "17.5%" }}>생성 시간</TableCell>}
-              {hideUpdatedAt === true && <TableCell sx={{ width: "17.5%" }}>수정 시간</TableCell>}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {listQuery.data?.map((item) => (
-              <TableRow key={item.id}>
-                <TableCell>
-                  <Link to={`/${app}/${resource}/${item.id}`}>{item.id}</Link>
-                </TableCell>
-                <TableCell>
-                  <Link to={`/${app}/${resource}/${item.id}`}>{item.str_repr}</Link>
-                </TableCell>
-                {!hideCreatedAt && <TableCell>{new Date(item.created_at).toLocaleString()}</TableCell>}
-                {!hideUpdatedAt && <TableCell>{new Date(item.updated_at).toLocaleString()}</TableCell>}
+      const handleFilterApply = (newParams: Record<string, string>) => setSearchParams(newParams, { replace: true });
+
+      const detailPath = (id: string) => `/${app}/${resource}/${id}`;
+      const hasCustomColumns = !!(columns && columns.length > 0);
+
+      const labelForRow = (item: ListRowType & Record<string, unknown>): string => {
+        if (hasCustomColumns) {
+          const firstField = columns![0].field;
+          const value = item[firstField];
+          if (typeof value === "string" && value.length > 0) return value;
+        }
+        return item.str_repr || item.id;
+      };
+
+      const handleDelete = (id: string, label: string) => {
+        if (!window.confirm(`'${label}'을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`)) return;
+        removeMutation.mutate(id, {
+          onSuccess: () => addSnackbar("삭제했습니다.", "success"),
+          onError: addErrorSnackbar,
+        });
+      };
+
+      return (
+        <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }}>
+          <Typography variant="h5">{title ?? `${app.toUpperCase()} > ${resource.toUpperCase()} > 목록`}</Typography>
+          <br />
+          <AdminListFilter parameters={queryParameters} values={filterParams} choices={choicesQuery.data} onApply={handleFilterApply} />
+          <Box>
+            {!hideCreateNew && (
+              <Button variant="contained" onClick={() => navigate(`/${app}/${resource}/create`)} startIcon={<Add />}>
+                새 객체 추가
+              </Button>
+            )}
+          </Box>
+          <Table>
+            <TableHead>
+              <TableRow>
+                {hasCustomColumns ? (
+                  columns!.map((col) => (
+                    <TableCell key={col.field} sx={{ width: col.width }} align={col.align}>
+                      {col.header}
+                    </TableCell>
+                  ))
+                ) : (
+                  <>
+                    <TableCell sx={{ width: "25%" }}>ID</TableCell>
+                    <TableCell sx={{ width: "40%" }}>이름</TableCell>
+                  </>
+                )}
+                {!hideCreatedAt && <TableCell sx={{ width: "17.5%" }}>생성 시간</TableCell>}
+                {!hideUpdatedAt && <TableCell sx={{ width: "17.5%" }}>수정 시간</TableCell>}
+                {enableRowActions && <TableCell sx={{ width: 120 }}>작업</TableCell>}
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </Stack>
-    );
-  })
+            </TableHead>
+            <TableBody>
+              {listQuery.data?.map((item) => (
+                <TableRow key={item.id} hover>
+                  {hasCustomColumns ? (
+                    columns!.map((col, idx) => {
+                      if (col.render) {
+                        return (
+                          <TableCell key={col.field} align={col.align}>
+                            {col.render(item)}
+                          </TableCell>
+                        );
+                      }
+                      const value = (item as Record<string, unknown>)[col.field];
+                      const displayValue = value === null || value === undefined ? "" : String(value);
+                      return (
+                        <TableCell key={col.field} align={col.align}>
+                          {idx === 0 ? <Link to={detailPath(item.id)}>{displayValue}</Link> : displayValue}
+                        </TableCell>
+                      );
+                    })
+                  ) : (
+                    <>
+                      <TableCell>
+                        <Link to={detailPath(item.id)}>{item.id}</Link>
+                      </TableCell>
+                      <TableCell>
+                        <Link to={detailPath(item.id)}>{item.str_repr}</Link>
+                      </TableCell>
+                    </>
+                  )}
+                  {!hideCreatedAt && <TableCell>{new Date(item.created_at).toLocaleString()}</TableCell>}
+                  {!hideUpdatedAt && <TableCell>{new Date(item.updated_at).toLocaleString()}</TableCell>}
+                  {enableRowActions && (
+                    <TableCell>
+                      <IconButton size="small" onClick={() => navigate(detailPath(item.id))} aria-label="수정">
+                        <Edit fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => handleDelete(item.id, labelForRow(item))}
+                        disabled={removeMutation.isPending}
+                        aria-label="삭제"
+                      >
+                        <Delete fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Stack>
+      );
+    }
+  )
 );
 
 export const AdminList: React.FC<AdminListProps> = (props) => (

--- a/apps/pyconkr-admin/src/components/pages/shop/_common/status_labels.ts
+++ b/apps/pyconkr-admin/src/components/pages/shop/_common/status_labels.ts
@@ -1,0 +1,25 @@
+import { OrderProductStatus, PaymentStatus } from "../order/types";
+import { ProductCurrentStatus } from "../product/types";
+
+type ChipColor = "default" | "primary" | "success" | "warning" | "error" | "info";
+
+export const PAYMENT_STATUS_LABEL: Record<PaymentStatus, { label: string; color: ChipColor }> = {
+  pending: { label: "대기", color: "default" },
+  completed: { label: "완료", color: "success" },
+  partial_refunded: { label: "부분환불", color: "warning" },
+  refunded: { label: "환불", color: "error" },
+};
+
+export const ORDER_PRODUCT_STATUS_LABEL: Record<OrderProductStatus, { label: string; color: ChipColor }> = {
+  pending: { label: "대기", color: "default" },
+  paid: { label: "결제완료", color: "success" },
+  used: { label: "사용", color: "info" },
+  refunded: { label: "환불", color: "error" },
+};
+
+export const PRODUCT_STATUS_LABEL: Record<ProductCurrentStatus, { label: string; color: ChipColor }> = {
+  hidden: { label: "비공개", color: "default" },
+  out_of_visible_period: { label: "노출 기간 아님", color: "default" },
+  out_of_orderable_period: { label: "판매 기간 아님", color: "warning" },
+  active: { label: "노출 중", color: "success" },
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/category_group/editor.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/category_group/editor.tsx
@@ -1,0 +1,232 @@
+import { useBackendAdminClient, useRetrieveQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { Add, Delete, Edit } from "@mui/icons-material";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import { useMutation } from "@tanstack/react-query";
+import * as React from "react";
+import { useParams } from "react-router-dom";
+
+import { addErrorSnackbar, addSnackbar } from "../../../../utils/snackbar";
+import { AdminEditor } from "../../../layouts/admin_editor";
+
+type Category = {
+  id?: string;
+  group?: string;
+  name: string;
+  priority: number;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type CategoryGroup = {
+  id: string;
+  name: string;
+  priority: number;
+  categories: Category[];
+};
+
+type CategoryFormValues = {
+  name: string;
+  priority: string;
+};
+
+type CategoryDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  group: CategoryGroup;
+  category?: Category;
+};
+
+const CategoryDialog: React.FC<CategoryDialogProps> = ({ open, onClose, group, category }) => {
+  const client = useBackendAdminClient();
+
+  const [values, setValues] = React.useState<CategoryFormValues>({
+    name: category?.name ?? "",
+    priority: category ? String(category.priority) : "0",
+  });
+
+  React.useEffect(() => {
+    if (open) {
+      setValues({
+        name: category?.name ?? "",
+        priority: category ? String(category.priority) : String((group.categories ?? []).length * 10),
+      });
+    }
+  }, [open, category, group.categories]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload: Category = {
+        ...(category ?? {}),
+        group: group.id,
+        name: values.name,
+        priority: Number(values.priority) || 0,
+      };
+      const newCategories = category
+        ? group.categories.map((c) => (c.id === category.id ? { ...c, ...payload } : c))
+        : [...group.categories, payload];
+      return client.patch(`v1/admin-api/shop/category-groups/${group.id}/`, {
+        ...group,
+        categories: newCategories,
+      });
+    },
+    onSuccess: () => {
+      addSnackbar(`카테고리 '${values.name}'을(를) ${category ? "수정" : "생성"}했습니다.`, "success");
+      onClose();
+    },
+    onError: addErrorSnackbar,
+  });
+
+  const onSubmit = () => {
+    if (!values.name.trim()) {
+      addSnackbar("이름은 필수입니다.", "error");
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <Dialog open={open} onClose={mutation.isPending ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{category ? `카테고리 수정: ${category.name}` : "새 카테고리 추가"}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="이름"
+            required
+            value={values.name}
+            onChange={(e) => setValues((p) => ({ ...p, name: e.target.value }))}
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="우선순위"
+            type="number"
+            value={values.priority}
+            onChange={(e) => setValues((p) => ({ ...p, priority: e.target.value }))}
+            fullWidth
+            helperText="낮은 값이 먼저 표시됩니다."
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={mutation.isPending}>
+          취소
+        </Button>
+        <Button variant="contained" onClick={onSubmit} disabled={mutation.isPending}>
+          {category ? "수정" : "추가"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const InnerChildCategoryList: React.FC<{ groupId: string }> = ErrorBoundary.with(
+  { fallback: () => null },
+  Suspense.with({ fallback: <CircularProgress /> }, ({ groupId }) => {
+    const client = useBackendAdminClient();
+    const groupQuery = useRetrieveQuery<CategoryGroup>(client, "shop", "category-groups", groupId);
+    const group = groupQuery.data;
+    const [dialogState, setDialogState] = React.useState<{ open: boolean; category?: Category }>({ open: false });
+
+    const deleteMutation = useMutation({
+      mutationFn: async (categoryId: string) => {
+        if (!group) return;
+        const newCategories = group.categories.filter((c) => c.id !== categoryId);
+        return client.patch(`v1/admin-api/shop/category-groups/${group.id}/`, { ...group, categories: newCategories });
+      },
+      onSuccess: () => addSnackbar("카테고리를 삭제했습니다.", "success"),
+      onError: addErrorSnackbar,
+    });
+
+    if (!group) return null;
+
+    const categories = [...(group.categories ?? [])].sort((a, b) => a.priority - b.priority);
+
+    const handleDelete = (category: Category) => {
+      if (!category.id) return;
+      if (window.confirm(`'${category.name}' 카테고리를 삭제하시겠습니까?`)) {
+        deleteMutation.mutate(category.id);
+      }
+    };
+
+    return (
+      <Stack spacing={2} sx={{ mt: 4 }}>
+        <Divider />
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">하위 카테고리 ({categories.length})</Typography>
+          <Button size="small" variant="outlined" startIcon={<Add />} onClick={() => setDialogState({ open: true })}>
+            카테고리 추가
+          </Button>
+        </Stack>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: "50%" }}>이름</TableCell>
+              <TableCell align="right">우선순위</TableCell>
+              <TableCell>생성일</TableCell>
+              <TableCell sx={{ width: 100 }}>작업</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {categories.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4} align="center" sx={{ color: "text.secondary" }}>
+                  하위 카테고리가 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+            {categories.map((category) => (
+              <TableRow key={category.id ?? category.name} hover>
+                <TableCell>{category.name}</TableCell>
+                <TableCell align="right">{category.priority}</TableCell>
+                <TableCell>{category.created_at ? new Date(category.created_at).toLocaleString() : "—"}</TableCell>
+                <TableCell>
+                  <IconButton size="small" onClick={() => setDialogState({ open: true, category })} aria-label="수정">
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" color="error" onClick={() => handleDelete(category)} aria-label="삭제" disabled={deleteMutation.isPending}>
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <CategoryDialog open={dialogState.open} onClose={() => setDialogState({ open: false })} group={group} category={dialogState.category} />
+      </Stack>
+    );
+  })
+);
+
+export const ShopCategoryGroupEditorPage: React.FC = () => {
+  const { id } = useParams<{ id?: string }>();
+
+  return (
+    <AdminEditor
+      app="shop"
+      resource="category-groups"
+      id={id}
+      hidingFields={["categories"]}
+      context={id ? undefined : ({ categories: [] } as unknown as Record<string, string>)}
+    >
+      {id && <InnerChildCategoryList groupId={id} />}
+    </AdminEditor>
+  );
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/category_group/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/category_group/list.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+
+import { AdminList, AdminListColumn } from "../../../layouts/admin_list";
+
+const columns: AdminListColumn[] = [
+  {
+    field: "name",
+    header: "이름",
+    width: "40%",
+    render: (row) => {
+      const id = row.id as string;
+      const name = String(row.name ?? "");
+      return <Link to={`/shop/category-groups/${id}`}>{name}</Link>;
+    },
+  },
+  {
+    field: "priority",
+    header: "우선순위",
+    align: "right",
+    render: (row) => String(row.priority ?? 0),
+  },
+  {
+    field: "categories",
+    header: "하위 카테고리 수",
+    align: "right",
+    render: (row) => {
+      const cats = row.categories;
+      return Array.isArray(cats) ? cats.length.toLocaleString() : "0";
+    },
+  },
+];
+
+export const ShopCategoryGroupListPage: React.FC = () => <AdminList app="shop" resource="category-groups" columns={columns} enableRowActions />;

--- a/apps/pyconkr-admin/src/components/pages/shop/order/editor.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/editor.tsx
@@ -1,0 +1,352 @@
+import { useBackendAdminClient, useRetrieveQuery, useUpdateMutation } from "@frontend/common/src/hooks/useAdminAPI";
+import { CurrencyExchange, NotificationsActive, Save } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tabs,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import * as React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { RefundDialog } from "./refund_dialog";
+import { OrderAdmin, SimpleCustomerInfo, SimpleOrderProductRelation } from "./types";
+import { addErrorSnackbar, addSnackbar } from "../../../../utils/snackbar";
+import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
+import { ErrorFallback } from "../../../elements/error_fallback";
+import { ORDER_PRODUCT_STATUS_LABEL, PAYMENT_STATUS_LABEL } from "../_common/status_labels";
+
+const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+
+// ----------------- Customer Info Tab (editable) -----------------
+const CustomerInfoTab: React.FC<{ order: OrderAdmin }> = ({ order }) => {
+  const client = useBackendAdminClient();
+  const updateMutation = useUpdateMutation<{ customer_info: SimpleCustomerInfo }>(client, "shop", "orders", order.id);
+
+  const [name, setName] = React.useState(order.customer_info?.name ?? "");
+  const [phone, setPhone] = React.useState(order.customer_info?.phone ?? "");
+  const [email, setEmail] = React.useState(order.customer_info?.email ?? "");
+  const [organization, setOrganization] = React.useState(order.customer_info?.organization ?? "");
+
+  React.useEffect(() => {
+    setName(order.customer_info?.name ?? "");
+    setPhone(order.customer_info?.phone ?? "");
+    setEmail(order.customer_info?.email ?? "");
+    setOrganization(order.customer_info?.organization ?? "");
+  }, [order.customer_info]);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!name.trim() || !phone.trim() || !email.trim()) {
+      addSnackbar("이름, 연락처, 이메일은 필수입니다.", "error");
+      return;
+    }
+    updateMutation.mutate({ customer_info: { name, phone, email, organization: organization || null } } as { customer_info: SimpleCustomerInfo }, {
+      onSuccess: () => addSnackbar("고객 정보를 수정했습니다.", "success"),
+      onError: addErrorSnackbar,
+    });
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Stack spacing={2}>
+        {!order.customer_info && (
+          <Alert severity="info" variant="outlined">
+            아직 고객 정보가 입력되지 않았습니다. 저장하면 신규 생성됩니다.
+          </Alert>
+        )}
+        <TextField label="이름" required value={name} onChange={(e) => setName(e.target.value)} fullWidth />
+        <TextField
+          label="연락처"
+          required
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          fullWidth
+          helperText="예: 010-1234-5678 또는 +821012345678"
+        />
+        <TextField label="이메일" required type="email" value={email} onChange={(e) => setEmail(e.target.value)} fullWidth />
+        <TextField label="소속" value={organization} onChange={(e) => setOrganization(e.target.value)} fullWidth />
+        <Stack direction="row" justifyContent="flex-end">
+          <Button type="submit" variant="contained" startIcon={<Save />} disabled={updateMutation.isPending}>
+            고객 정보 저장
+          </Button>
+        </Stack>
+      </Stack>
+    </form>
+  );
+};
+
+const OrderProductRow: React.FC<{ relation: SimpleOrderProductRelation }> = ({ relation }) => {
+  const status = ORDER_PRODUCT_STATUS_LABEL[relation.status];
+  return (
+    <>
+      <TableRow hover>
+        <TableCell>
+          <code>{relation.id.slice(0, 8)}</code>
+        </TableCell>
+        <TableCell>{relation.product.name_ko || relation.product.name_en}</TableCell>
+        <TableCell>
+          <Chip label={status.label} size="small" color={status.color} />
+        </TableCell>
+        <TableCell align="right">{formatPrice(relation.price)}</TableCell>
+        <TableCell align="right">{relation.donation_price > 0 ? formatPrice(relation.donation_price) : "—"}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell colSpan={5} sx={{ bgcolor: "action.hover", py: 1, pl: 4 }}>
+          {relation.options.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              옵션 없음
+            </Typography>
+          ) : (
+            <Table size="small" sx={{ width: "auto" }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ minWidth: 140 }}>옵션 그룹</TableCell>
+                  <TableCell sx={{ minWidth: 240 }}>옵션 / 입력</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {relation.options.map((opt) => (
+                  <TableRow key={opt.id}>
+                    <TableCell>{opt.option_group_name_ko || opt.option_group_name_en}</TableCell>
+                    <TableCell>
+                      {opt.option_name_ko || opt.option_name_en ? (
+                        opt.option_name_ko || opt.option_name_en
+                      ) : (
+                        <Typography component="span" variant="body2" color="text.secondary">
+                          사용자 입력: {opt.custom_response || "(없음)"}
+                        </Typography>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </TableCell>
+      </TableRow>
+    </>
+  );
+};
+
+const OrderProductsTab: React.FC<{ order: OrderAdmin }> = ({ order }) => (
+  <Table>
+    <TableHead>
+      <TableRow>
+        <TableCell>주문 상품 ID</TableCell>
+        <TableCell>상품명</TableCell>
+        <TableCell>상태</TableCell>
+        <TableCell align="right">가격</TableCell>
+        <TableCell align="right">기부</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {order.products.length === 0 && (
+        <TableRow>
+          <TableCell colSpan={5} align="center" sx={{ color: "text.secondary" }}>
+            주문 상품이 없습니다.
+          </TableCell>
+        </TableRow>
+      )}
+      {order.products.map((p) => (
+        <OrderProductRow key={p.id} relation={p} />
+      ))}
+    </TableBody>
+  </Table>
+);
+
+const PaymentHistoryTab: React.FC<{ order: OrderAdmin; onRefund: () => void }> = ({ order, onRefund }) => {
+  const histories = [...order.payment_histories].sort((a, b) => (a.created_at < b.created_at ? -1 : 1));
+  const canRefund = order.current_paid_price > 0 && (order.current_status === "completed" || order.current_status === "partial_refunded");
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="body2" color="text.secondary">
+          PortOne imp_id 기준 결제 이력입니다.
+        </Typography>
+        <Button variant="outlined" color="error" startIcon={<CurrencyExchange />} onClick={onRefund} disabled={!canRefund}>
+          환불 처리
+        </Button>
+      </Stack>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>일시</TableCell>
+            <TableCell>imp_id</TableCell>
+            <TableCell>상태</TableCell>
+            <TableCell align="right">금액</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {histories.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={4} align="center" sx={{ color: "text.secondary" }}>
+                결제 이력이 없습니다.
+              </TableCell>
+            </TableRow>
+          )}
+          {histories.map((h, idx) => {
+            const status = PAYMENT_STATUS_LABEL[h.status] ?? { label: h.status, color: "default" as const };
+            const isLatest = idx === histories.length - 1;
+            return (
+              <TableRow key={h.id} hover sx={isLatest ? { "& td": { fontWeight: 600 } } : undefined}>
+                <TableCell>{new Date(h.created_at).toLocaleString()}</TableCell>
+                <TableCell>
+                  <code>{h.imp_id}</code>
+                </TableCell>
+                <TableCell>
+                  <Chip label={status.label} size="small" color={status.color} />
+                </TableCell>
+                <TableCell align="right">{formatPrice(h.price)}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Stack>
+  );
+};
+
+const InnerOrderEditor: React.FC = ErrorBoundary.with(
+  { fallback: ErrorFallback },
+  Suspense.with({ fallback: <CircularProgress /> }, () => {
+    const { id } = useParams<{ id?: string }>();
+    const navigate = useNavigate();
+    const client = useBackendAdminClient();
+    const [tab, setTab] = React.useState(0);
+    const [refundOpen, setRefundOpen] = React.useState(false);
+
+    const orderQuery = useRetrieveQuery<OrderAdmin>(client, "shop", "orders", id ?? "");
+    const order = orderQuery.data;
+
+    if (!order) {
+      return (
+        <Stack sx={{ flexGrow: 1, width: "100%" }} spacing={2}>
+          <Typography variant="h5">SHOP &gt; ORDERS</Typography>
+          <Alert severity="error">해당 ID의 주문을 찾을 수 없습니다.</Alert>
+          <Button variant="outlined" onClick={() => navigate("/shop/orders")} sx={{ alignSelf: "flex-start" }}>
+            목록으로
+          </Button>
+        </Stack>
+      );
+    }
+
+    const status = PAYMENT_STATUS_LABEL[order.current_status] ?? { label: order.current_status, color: "default" as const };
+    const canRefund = order.current_paid_price > 0 && (order.current_status === "completed" || order.current_status === "partial_refunded");
+
+    const onNotify = () => {
+      navigate({
+        pathname: "/notification/notification/create",
+        search: `?order_id=${order.id}`,
+      });
+    };
+
+    return (
+      <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }} spacing={3}>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap={2}>
+          <Stack spacing={1}>
+            <Typography variant="h5">
+              SHOP &gt; ORDERS &gt; 상세: <code>{order.id.slice(0, 8)}</code>
+            </Typography>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip label={status.label} color={status.color} />
+              <Typography variant="body1">
+                <strong>{formatPrice(order.current_paid_price)}</strong>
+                {order.first_paid_price !== order.current_paid_price && (
+                  <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                    (최초 결제: {formatPrice(order.first_paid_price)})
+                  </Typography>
+                )}
+              </Typography>
+              {order.user && (
+                <Typography variant="body2" color="text.secondary">
+                  · {order.user.email}
+                </Typography>
+              )}
+            </Stack>
+          </Stack>
+
+          <Stack direction="row" spacing={1}>
+            <Button variant="outlined" startIcon={<NotificationsActive />} onClick={onNotify}>
+              알림 발송
+            </Button>
+            <Button variant="contained" color="error" startIcon={<CurrencyExchange />} onClick={() => setRefundOpen(true)} disabled={!canRefund}>
+              환불
+            </Button>
+          </Stack>
+        </Stack>
+
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: "30%" }}>필드</TableCell>
+              <TableCell>값</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>
+                <code>{order.id}</code>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>주문일</TableCell>
+              <TableCell>{new Date(order.created_at).toLocaleString()}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>최초 결제일</TableCell>
+              <TableCell>{order.first_paid_at ? new Date(order.first_paid_at).toLocaleString() : "—"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>최근 imp_id</TableCell>
+              <TableCell>
+                <code>{order.latest_imp_id || "—"}</code>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>마지막 수정</TableCell>
+              <TableCell>{new Date(order.updated_at).toLocaleString()}</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+
+        <Divider />
+
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab label="고객 정보" />
+          <Tab label="상품" />
+          <Tab label="결제 이력" />
+        </Tabs>
+
+        <Box>
+          {tab === 0 && <CustomerInfoTab order={order} />}
+          {tab === 1 && <OrderProductsTab order={order} />}
+          {tab === 2 && <PaymentHistoryTab order={order} onRefund={() => setRefundOpen(true)} />}
+        </Box>
+
+        <RefundDialog open={refundOpen} onClose={() => setRefundOpen(false)} order={order} />
+      </Stack>
+    );
+  })
+);
+
+export const ShopOrderEditorPage: React.FC = () => (
+  <BackendAdminSignInGuard>
+    <InnerOrderEditor />
+  </BackendAdminSignInGuard>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
@@ -1,4 +1,4 @@
-import { useBackendAdminClient, useListQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { useBackendAdminClient, useListPaginatedQuery } from "@frontend/common/src/hooks/useAdminAPI";
 import {
   Chip,
   CircularProgress,
@@ -18,6 +18,7 @@ import * as React from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
 import { OrderAdmin, PaymentStatus } from "./types";
+import { AdminPagination } from "../../../elements/admin_pagination";
 import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
 import { ErrorFallback } from "../../../elements/error_fallback";
 import { PAYMENT_STATUS_LABEL } from "../_common/status_labels";
@@ -36,20 +37,37 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
     const emailQuery = searchParams.get("email") ?? "";
     const impIdQuery = searchParams.get("imp_id") ?? "";
     const statusQuery = (searchParams.get("status") ?? "all") as StatusFilter;
+    const page = Number(searchParams.get("page") ?? 1);
+    const pageSize = Number(searchParams.get("page_size") ?? 50);
 
-    const apiParams: Record<string, string> = {};
+    const apiParams: Record<string, string> = { page: String(page), page_size: String(pageSize) };
     if (nameQuery.trim()) apiParams.name = nameQuery.trim();
     if (emailQuery.trim()) apiParams.email = emailQuery.trim();
     if (impIdQuery.trim()) apiParams.imp_id = impIdQuery.trim();
     if (statusQuery !== "all") apiParams.status = statusQuery;
 
-    const ordersQuery = useListQuery<OrderAdmin>(client, "shop", "orders", apiParams);
-    const orders = ordersQuery.data ?? [];
+    const ordersQuery = useListPaginatedQuery<OrderAdmin>(client, "shop", "orders", apiParams);
+    const { count = 0, results: orders = [] } = ordersQuery.data ?? {};
 
-    const updateParam = (key: string, value: string) => {
+    const updateFilterParam = (key: string, value: string) => {
       const next = new URLSearchParams(searchParams);
       if (value) next.set(key, value);
       else next.delete(key);
+      next.delete("page");
+      setSearchParams(next, { replace: true });
+    };
+
+    const setPage = (p: number) => {
+      const next = new URLSearchParams(searchParams);
+      if (p <= 1) next.delete("page");
+      else next.set("page", String(p));
+      setSearchParams(next, { replace: true });
+    };
+
+    const setPageSize = (size: number) => {
+      const next = new URLSearchParams(searchParams);
+      next.set("page_size", String(size));
+      next.delete("page");
       setSearchParams(next, { replace: true });
     };
 
@@ -62,27 +80,27 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
             size="small"
             label="이름 검색 (사용자/고객)"
             value={nameQuery}
-            onChange={(e) => updateParam("name", e.target.value)}
+            onChange={(e) => updateFilterParam("name", e.target.value)}
             sx={{ minWidth: 220 }}
           />
           <TextField
             size="small"
             label="이메일 검색"
             value={emailQuery}
-            onChange={(e) => updateParam("email", e.target.value)}
+            onChange={(e) => updateFilterParam("email", e.target.value)}
             sx={{ minWidth: 220 }}
           />
           <TextField
             size="small"
             label="PortOne imp_id"
             value={impIdQuery}
-            onChange={(e) => updateParam("imp_id", e.target.value)}
+            onChange={(e) => updateFilterParam("imp_id", e.target.value)}
             sx={{ minWidth: 200 }}
           />
           <Select
             size="small"
             value={statusQuery}
-            onChange={(e) => updateParam("status", e.target.value === "all" ? "" : (e.target.value as string))}
+            onChange={(e) => updateFilterParam("status", e.target.value === "all" ? "" : (e.target.value as string))}
             sx={{ minWidth: 140 }}
           >
             <MenuItem value="all">전체 상태</MenuItem>
@@ -91,9 +109,6 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
             <MenuItem value="partial_refunded">부분환불</MenuItem>
             <MenuItem value="refunded">환불</MenuItem>
           </Select>
-          <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
-            {orders.length} 건
-          </Typography>
         </Stack>
 
         <Table>
@@ -138,6 +153,8 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
             })}
           </TableBody>
         </Table>
+
+        <AdminPagination count={count} page={page} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
       </Stack>
     );
   })

--- a/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
@@ -1,4 +1,4 @@
-import { useBackendAdminClient, useListPaginatedQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { useBackendAdminClient, useListPaginatedQuery, useListQuery } from "@frontend/common/src/hooks/useAdminAPI";
 import {
   Chip,
   CircularProgress,
@@ -18,12 +18,16 @@ import * as React from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
 import { OrderAdmin, PaymentStatus } from "./types";
+import { AdminFilterFieldset } from "../../../elements/admin_filter_fieldset";
 import { AdminPagination } from "../../../elements/admin_pagination";
 import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
 import { ErrorFallback } from "../../../elements/error_fallback";
 import { PAYMENT_STATUS_LABEL } from "../_common/status_labels";
+import { CategoryGroupAdminWithCategories } from "../product/types";
 
 const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+
+const DEFAULT_PAGE_SIZE = 50;
 
 type StatusFilter = "all" | PaymentStatus;
 
@@ -37,22 +41,45 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
     const emailQuery = searchParams.get("email") ?? "";
     const impIdQuery = searchParams.get("imp_id") ?? "";
     const statusQuery = (searchParams.get("status") ?? "all") as StatusFilter;
+    const categoryGroupQuery = searchParams.get("category_group_id") ?? "";
+    const categoryQuery = searchParams.get("category_id") ?? "";
+    const paidAfter = searchParams.get("first_paid_at_after") ?? "";
+    const paidBefore = searchParams.get("first_paid_at_before") ?? "";
+    const statusChangedAfter = searchParams.get("status_changed_at_after") ?? "";
+    const statusChangedBefore = searchParams.get("status_changed_at_before") ?? "";
     const page = Number(searchParams.get("page") ?? 1);
-    const pageSize = Number(searchParams.get("page_size") ?? 50);
+    const pageSize = Number(searchParams.get("page_size") ?? DEFAULT_PAGE_SIZE);
 
     const apiParams: Record<string, string> = { page: String(page), page_size: String(pageSize) };
     if (nameQuery.trim()) apiParams.name = nameQuery.trim();
     if (emailQuery.trim()) apiParams.email = emailQuery.trim();
     if (impIdQuery.trim()) apiParams.imp_id = impIdQuery.trim();
     if (statusQuery !== "all") apiParams.status = statusQuery;
+    if (categoryGroupQuery) apiParams.category_group_id = categoryGroupQuery;
+    if (categoryQuery) apiParams.category_id = categoryQuery;
+    if (paidAfter) apiParams.first_paid_at_after = paidAfter;
+    if (paidBefore) apiParams.first_paid_at_before = paidBefore;
+    if (statusChangedAfter) apiParams.status_changed_at_after = statusChangedAfter;
+    if (statusChangedBefore) apiParams.status_changed_at_before = statusChangedBefore;
 
     const ordersQuery = useListPaginatedQuery<OrderAdmin>(client, "shop", "orders", apiParams);
+    const groupsQuery = useListQuery<CategoryGroupAdminWithCategories>(client, "shop", "category-groups", {});
     const { count = 0, results: orders = [] } = ordersQuery.data ?? {};
+    const groups = React.useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
 
     const updateFilterParam = (key: string, value: string) => {
       const next = new URLSearchParams(searchParams);
       if (value) next.set(key, value);
       else next.delete(key);
+      next.delete("page");
+      setSearchParams(next, { replace: true });
+    };
+
+    const setCategoryGroup = (value: string) => {
+      const next = new URLSearchParams(searchParams);
+      if (value) next.set("category_group_id", value);
+      else next.delete("category_group_id");
+      next.delete("category_id"); // 그룹 바꾸면 카테고리 선택 초기화
       next.delete("page");
       setSearchParams(next, { replace: true });
     };
@@ -75,40 +102,114 @@ const InnerOrderList: React.FC = ErrorBoundary.with(
       <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }} spacing={2}>
         <Typography variant="h5">SHOP &gt; ORDERS &gt; 목록</Typography>
 
-        <Stack direction="row" spacing={2} flexWrap="wrap" alignItems="center">
-          <TextField
-            size="small"
-            label="이름 검색 (사용자/고객)"
-            value={nameQuery}
-            onChange={(e) => updateFilterParam("name", e.target.value)}
-            sx={{ minWidth: 220 }}
-          />
-          <TextField
-            size="small"
-            label="이메일 검색"
-            value={emailQuery}
-            onChange={(e) => updateFilterParam("email", e.target.value)}
-            sx={{ minWidth: 220 }}
-          />
-          <TextField
-            size="small"
-            label="PortOne imp_id"
-            value={impIdQuery}
-            onChange={(e) => updateFilterParam("imp_id", e.target.value)}
-            sx={{ minWidth: 200 }}
-          />
-          <Select
-            size="small"
-            value={statusQuery}
-            onChange={(e) => updateFilterParam("status", e.target.value === "all" ? "" : (e.target.value as string))}
-            sx={{ minWidth: 140 }}
-          >
-            <MenuItem value="all">전체 상태</MenuItem>
-            <MenuItem value="pending">대기</MenuItem>
-            <MenuItem value="completed">완료</MenuItem>
-            <MenuItem value="partial_refunded">부분환불</MenuItem>
-            <MenuItem value="refunded">환불</MenuItem>
-          </Select>
+        <Stack direction="row" flexWrap="wrap" sx={{ gap: 2, alignItems: "flex-start" }}>
+          <AdminFilterFieldset label="결제일 범위">
+            <TextField
+              size="small"
+              label="시작"
+              type="datetime-local"
+              value={paidAfter?.slice(0, 16) ?? ""}
+              onChange={(e) => updateFilterParam("first_paid_at_after", e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+              sx={{ minWidth: 220 }}
+            />
+            <TextField
+              size="small"
+              label="종료"
+              type="datetime-local"
+              value={paidBefore?.slice(0, 16) ?? ""}
+              onChange={(e) => updateFilterParam("first_paid_at_before", e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+              sx={{ minWidth: 220 }}
+            />
+          </AdminFilterFieldset>
+
+          <AdminFilterFieldset label="상태 변경일 범위">
+            <TextField
+              size="small"
+              label="시작"
+              type="datetime-local"
+              value={statusChangedAfter?.slice(0, 16) ?? ""}
+              onChange={(e) => updateFilterParam("status_changed_at_after", e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+              sx={{ minWidth: 220 }}
+            />
+            <TextField
+              size="small"
+              label="종료"
+              type="datetime-local"
+              value={statusChangedBefore?.slice(0, 16) ?? ""}
+              onChange={(e) => updateFilterParam("status_changed_at_before", e.target.value)}
+              slotProps={{ inputLabel: { shrink: true } }}
+              sx={{ minWidth: 220 }}
+            />
+          </AdminFilterFieldset>
+
+          <AdminFilterFieldset label="분류">
+            <Select
+              size="small"
+              value={statusQuery}
+              onChange={(e) => updateFilterParam("status", e.target.value === "all" ? "" : (e.target.value as string))}
+              sx={{ minWidth: 140 }}
+            >
+              <MenuItem value="all">전체 상태</MenuItem>
+              <MenuItem value="pending">대기</MenuItem>
+              <MenuItem value="completed">완료</MenuItem>
+              <MenuItem value="partial_refunded">부분환불</MenuItem>
+              <MenuItem value="refunded">환불</MenuItem>
+            </Select>
+            <Select size="small" value={categoryGroupQuery} onChange={(e) => setCategoryGroup(e.target.value)} displayEmpty sx={{ minWidth: 200 }}>
+              <MenuItem value="">전체 카테고리 그룹</MenuItem>
+              {groups.map((g) => (
+                <MenuItem key={g.id} value={g.id}>
+                  {g.name}
+                </MenuItem>
+              ))}
+            </Select>
+            <Select
+              size="small"
+              value={categoryQuery}
+              onChange={(e) => updateFilterParam("category_id", e.target.value)}
+              displayEmpty
+              sx={{ minWidth: 200 }}
+            >
+              <MenuItem value="">전체 카테고리</MenuItem>
+              {(categoryGroupQuery ? groups.filter((g) => g.id === categoryGroupQuery) : groups).flatMap((group) => [
+                <MenuItem key={`group-${group.id}`} disabled sx={{ fontWeight: 600, opacity: "0.8 !important" }}>
+                  {group.name}
+                </MenuItem>,
+                ...(group.categories ?? []).map((c) => (
+                  <MenuItem key={c.id} value={c.id} sx={{ pl: 4 }}>
+                    {c.name}
+                  </MenuItem>
+                )),
+              ])}
+            </Select>
+          </AdminFilterFieldset>
+
+          <AdminFilterFieldset label="검색">
+            <TextField
+              size="small"
+              label="이름 (사용자/고객)"
+              value={nameQuery}
+              onChange={(e) => updateFilterParam("name", e.target.value)}
+              sx={{ minWidth: 220 }}
+            />
+            <TextField
+              size="small"
+              label="이메일"
+              value={emailQuery}
+              onChange={(e) => updateFilterParam("email", e.target.value)}
+              sx={{ minWidth: 220 }}
+            />
+            <TextField
+              size="small"
+              label="PortOne imp_id"
+              value={impIdQuery}
+              onChange={(e) => updateFilterParam("imp_id", e.target.value)}
+              sx={{ minWidth: 200 }}
+            />
+          </AdminFilterFieldset>
         </Stack>
 
         <Table>

--- a/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/list.tsx
@@ -1,0 +1,150 @@
+import { useBackendAdminClient, useListQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import {
+  Chip,
+  CircularProgress,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import * as React from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { OrderAdmin, PaymentStatus } from "./types";
+import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
+import { ErrorFallback } from "../../../elements/error_fallback";
+import { PAYMENT_STATUS_LABEL } from "../_common/status_labels";
+
+const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+
+type StatusFilter = "all" | PaymentStatus;
+
+const InnerOrderList: React.FC = ErrorBoundary.with(
+  { fallback: ErrorFallback },
+  Suspense.with({ fallback: <CircularProgress /> }, () => {
+    const client = useBackendAdminClient();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const nameQuery = searchParams.get("name") ?? "";
+    const emailQuery = searchParams.get("email") ?? "";
+    const impIdQuery = searchParams.get("imp_id") ?? "";
+    const statusQuery = (searchParams.get("status") ?? "all") as StatusFilter;
+
+    const apiParams: Record<string, string> = {};
+    if (nameQuery.trim()) apiParams.name = nameQuery.trim();
+    if (emailQuery.trim()) apiParams.email = emailQuery.trim();
+    if (impIdQuery.trim()) apiParams.imp_id = impIdQuery.trim();
+    if (statusQuery !== "all") apiParams.status = statusQuery;
+
+    const ordersQuery = useListQuery<OrderAdmin>(client, "shop", "orders", apiParams);
+    const orders = ordersQuery.data ?? [];
+
+    const updateParam = (key: string, value: string) => {
+      const next = new URLSearchParams(searchParams);
+      if (value) next.set(key, value);
+      else next.delete(key);
+      setSearchParams(next, { replace: true });
+    };
+
+    return (
+      <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }} spacing={2}>
+        <Typography variant="h5">SHOP &gt; ORDERS &gt; 목록</Typography>
+
+        <Stack direction="row" spacing={2} flexWrap="wrap" alignItems="center">
+          <TextField
+            size="small"
+            label="이름 검색 (사용자/고객)"
+            value={nameQuery}
+            onChange={(e) => updateParam("name", e.target.value)}
+            sx={{ minWidth: 220 }}
+          />
+          <TextField
+            size="small"
+            label="이메일 검색"
+            value={emailQuery}
+            onChange={(e) => updateParam("email", e.target.value)}
+            sx={{ minWidth: 220 }}
+          />
+          <TextField
+            size="small"
+            label="PortOne imp_id"
+            value={impIdQuery}
+            onChange={(e) => updateParam("imp_id", e.target.value)}
+            sx={{ minWidth: 200 }}
+          />
+          <Select
+            size="small"
+            value={statusQuery}
+            onChange={(e) => updateParam("status", e.target.value === "all" ? "" : (e.target.value as string))}
+            sx={{ minWidth: 140 }}
+          >
+            <MenuItem value="all">전체 상태</MenuItem>
+            <MenuItem value="pending">대기</MenuItem>
+            <MenuItem value="completed">완료</MenuItem>
+            <MenuItem value="partial_refunded">부분환불</MenuItem>
+            <MenuItem value="refunded">환불</MenuItem>
+          </Select>
+          <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
+            {orders.length} 건
+          </Typography>
+        </Stack>
+
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: "12%" }}>주문 ID</TableCell>
+              <TableCell>사용자</TableCell>
+              <TableCell>이름</TableCell>
+              <TableCell>상태</TableCell>
+              <TableCell align="right">결제액</TableCell>
+              <TableCell>결제일</TableCell>
+              <TableCell>생성일</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {orders.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ color: "text.secondary" }}>
+                  조건에 맞는 주문이 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+            {orders.map((order) => {
+              const status = PAYMENT_STATUS_LABEL[order.current_status] ?? { label: order.current_status, color: "default" as const };
+              return (
+                <TableRow key={order.id} hover>
+                  <TableCell>
+                    <Link to={`/shop/orders/${order.id}`}>
+                      <code>{order.id.slice(0, 8)}</code>
+                    </Link>
+                  </TableCell>
+                  <TableCell>{order.user?.email ?? "—"}</TableCell>
+                  <TableCell>{order.name_ko || order.str_repr}</TableCell>
+                  <TableCell>
+                    <Chip label={status.label} size="small" color={status.color} />
+                  </TableCell>
+                  <TableCell align="right">{formatPrice(order.current_paid_price)}</TableCell>
+                  <TableCell>{order.first_paid_at ? new Date(order.first_paid_at).toLocaleString() : "—"}</TableCell>
+                  <TableCell>{new Date(order.created_at).toLocaleString()}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Stack>
+    );
+  })
+);
+
+export const ShopOrderListPage: React.FC = () => (
+  <BackendAdminSignInGuard>
+    <InnerOrderList />
+  </BackendAdminSignInGuard>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/order/refund_dialog.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/refund_dialog.tsx
@@ -1,0 +1,91 @@
+import { useBackendAdminClient } from "@frontend/common/src/hooks/useAdminAPI";
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack, TextField, Typography } from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import * as React from "react";
+
+import { OrderAdmin } from "./types";
+import { addErrorSnackbar, addSnackbar } from "../../../../utils/snackbar";
+
+type RefundDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  order: OrderAdmin;
+};
+
+const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+
+export const RefundDialog: React.FC<RefundDialogProps> = ({ open, onClose, order }) => {
+  const client = useBackendAdminClient();
+  const [totp, setTotp] = React.useState("");
+  const [touched, setTouched] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) {
+      setTotp("");
+      setTouched(false);
+    }
+  }, [open]);
+
+  const refundMutation = useMutation({
+    mutationFn: async (totpCode: string) => {
+      return client.post<void, Record<string, string>>(`v1/admin-api/shop/orders/${order.id}/refund/?totp=${encodeURIComponent(totpCode)}`, {
+        totp: totpCode,
+      });
+    },
+    onSuccess: () => {
+      addSnackbar(`주문 '${order.name_ko || order.str_repr}'의 전액 환불(${formatPrice(order.current_paid_price)})이 처리되었습니다.`, "success");
+      onClose();
+    },
+    onError: addErrorSnackbar,
+  });
+
+  const totpInvalid = touched && totp.trim().length === 0;
+  const disabled = refundMutation.isPending;
+
+  const onSubmit = () => {
+    setTouched(true);
+    if (totp.trim().length === 0) return;
+    refundMutation.mutate(totp.trim());
+  };
+
+  return (
+    <Dialog open={open} onClose={disabled ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>환불 처리</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2">
+            주문: <strong>{order.name_ko || order.str_repr}</strong>
+          </Typography>
+          <Typography variant="body2">
+            현재 결제액: <strong>{formatPrice(order.current_paid_price)}</strong>
+          </Typography>
+
+          <Alert severity="warning">
+            <strong>전액 환불</strong>만 지원됩니다. 환불 가능한 상태의 모든 상품이 환불 처리되며, 이 작업은 되돌릴 수 없습니다.
+          </Alert>
+
+          <TextField
+            label="TOTP 인증 코드"
+            required
+            autoFocus
+            value={totp}
+            onChange={(e) => setTotp(e.target.value)}
+            error={totpInvalid}
+            helperText={totpInvalid ? "TOTP 코드는 필수입니다." : "환불 권한자의 인증 앱에서 6자리 코드를 입력하세요."}
+            fullWidth
+            disabled={disabled}
+            slotProps={{ htmlInput: { autoComplete: "one-time-code", inputMode: "numeric" } }}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={disabled}>
+          취소
+        </Button>
+        <Button variant="contained" color="error" onClick={onSubmit} disabled={disabled}>
+          환불 처리
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/order/types.ts
+++ b/apps/pyconkr-admin/src/components/pages/shop/order/types.ts
@@ -1,0 +1,67 @@
+export type PaymentStatus = "pending" | "completed" | "partial_refunded" | "refunded";
+export type OrderProductStatus = "pending" | "paid" | "used" | "refunded";
+
+export type SimpleUser = {
+  id: string;
+  username: string;
+  email: string;
+  unique_id: string;
+};
+
+export type SimpleCustomerInfo = {
+  name: string;
+  phone: string;
+  email: string;
+  organization: string | null;
+};
+
+export type SimpleProduct = {
+  id: string;
+  name_ko: string;
+  name_en: string;
+  price: number;
+};
+
+export type SimpleOrderProductOptionRelation = {
+  id: string;
+  option_group_name_ko: string;
+  option_group_name_en: string;
+  option_name_ko: string | null;
+  option_name_en: string | null;
+  custom_response: string | null;
+};
+
+export type SimpleOrderProductRelation = {
+  id: string;
+  product: SimpleProduct;
+  status: OrderProductStatus;
+  price: number;
+  donation_price: number;
+  options: SimpleOrderProductOptionRelation[];
+};
+
+export type SimplePaymentHistory = {
+  id: string;
+  imp_id: string;
+  status: PaymentStatus;
+  price: number;
+  created_at: string;
+};
+
+export type OrderAdmin = {
+  id: string;
+  str_repr: string;
+  created_at: string;
+  updated_at: string;
+  name_ko: string;
+  name_en: string;
+  user: SimpleUser | null;
+  customer_info: SimpleCustomerInfo | null;
+  products: SimpleOrderProductRelation[];
+  payment_histories: SimplePaymentHistory[];
+  first_paid_price: number;
+  current_paid_price: number;
+  current_status: PaymentStatus;
+  first_paid_at: string | null;
+  latest_imp_id: string | null;
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/product/editor.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/editor.tsx
@@ -1,0 +1,256 @@
+import {
+  useBackendAdminClient,
+  useCreateMutation,
+  useListQuery,
+  useRemoveMutation,
+  useRetrieveQuery,
+  useUpdateMutation,
+} from "@frontend/common/src/hooks/useAdminAPI";
+import { Add, Delete, Edit } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  Stack,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tabs,
+  Typography,
+} from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import * as React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { buildDefaultFormValues, ProductFormValues, toPayload } from "./form";
+import { BasicInfoTab } from "./tabs/basic_info_tab";
+import { OptionGroupsTab } from "./tabs/option_groups_tab";
+import { PriceOptionsTab } from "./tabs/price_options_tab";
+import { TimeSettingsTab } from "./tabs/time_settings_tab";
+import { CategoryGroupAdminWithCategories, ProductAdmin, TagAdmin } from "./types";
+import { addErrorSnackbar, addSnackbar } from "../../../../utils/snackbar";
+import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
+import { ErrorFallback } from "../../../elements/error_fallback";
+
+const formatLeftover = (v: number | null | undefined): React.ReactNode =>
+  v === undefined ? (
+    <Typography component="span" variant="body2" color="text.disabled">
+      —
+    </Typography>
+  ) : v === null ? (
+    "무한대"
+  ) : (
+    v.toLocaleString()
+  );
+
+const InnerProductEditor: React.FC = ErrorBoundary.with(
+  { fallback: ErrorFallback },
+  Suspense.with({ fallback: <CircularProgress /> }, () => {
+    const { id } = useParams<{ id?: string }>();
+    const navigate = useNavigate();
+    const client = useBackendAdminClient();
+
+    const isCreate = !id;
+    const productQuery = useRetrieveQuery<ProductAdmin>(client, "shop", "products", id ?? "");
+    const groupsQuery = useListQuery<CategoryGroupAdminWithCategories>(client, "shop", "category-groups", {});
+    const tagsQuery = useListQuery<TagAdmin>(client, "shop", "tags", {});
+
+    const existing = isCreate ? undefined : (productQuery.data ?? undefined);
+    const groups = groupsQuery.data ?? [];
+    const tags = tagsQuery.data ?? [];
+
+    const [tab, setTab] = React.useState(0);
+    const [values, setValues] = React.useState<ProductFormValues>(() => buildDefaultFormValues(existing));
+
+    React.useEffect(() => {
+      if (existing) setValues(buildDefaultFormValues(existing));
+    }, [existing]);
+
+    const createMutation = useCreateMutation<ProductAdmin>(client, "shop", "products");
+    const updateMutation = useUpdateMutation<ProductAdmin>(client, "shop", "products", id ?? "");
+    const deleteMutation = useRemoveMutation(client, "shop", "products", id ?? "");
+
+    const setField = <K extends keyof ProductFormValues>(key: K, value: ProductFormValues[K]) => {
+      setValues((prev) => ({ ...prev, [key]: value }));
+    };
+
+    const onSubmit = () => {
+      if (!values.name_ko.trim()) {
+        addSnackbar("한국어 이름은 필수입니다.", "error");
+        return;
+      }
+      if (!values.category) {
+        addSnackbar("카테고리는 필수입니다.", "error");
+        return;
+      }
+      const payload = toPayload(values);
+      if (existing) {
+        updateMutation.mutate(payload as unknown as ProductAdmin, {
+          onSuccess: () => addSnackbar("상품을 수정했습니다.", "success"),
+          onError: addErrorSnackbar,
+        });
+      } else {
+        createMutation.mutate(payload as unknown as ProductAdmin, {
+          onSuccess: (data) => {
+            addSnackbar("상품을 생성했습니다.", "success");
+            navigate(`/shop/products/${(data as unknown as ProductAdmin).id}`);
+          },
+          onError: addErrorSnackbar,
+        });
+      }
+    };
+
+    const onDelete = () => {
+      if (!existing) return;
+      if (window.confirm(`'${existing.name_ko}' 상품을 삭제하시겠습니까?`)) {
+        deleteMutation.mutate(undefined, {
+          onSuccess: () => {
+            addSnackbar("상품을 삭제했습니다.", "success");
+            navigate("/shop/products");
+          },
+          onError: addErrorSnackbar,
+        });
+      }
+    };
+
+    const title = `SHOP > PRODUCTS > ${existing ? `편집: ${existing.name_ko}` : "새 객체 추가"}`;
+    const disabled = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
+
+    return (
+      <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }} spacing={3}>
+        <Typography variant="h5">{title}</Typography>
+
+        {existing && (
+          <Stack spacing={2}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ width: "30%" }}>필드</TableCell>
+                  <TableCell>값</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell>ID</TableCell>
+                  <TableCell>
+                    <code>{existing.id}</code>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>생성일</TableCell>
+                  <TableCell>{new Date(existing.created_at).toLocaleString()}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>수정일</TableCell>
+                  <TableCell>{new Date(existing.updated_at).toLocaleString()}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+
+            <Box>
+              <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
+                재고 제약
+              </Typography>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ width: "55%" }}>제약</TableCell>
+                    <TableCell align="right">한도</TableCell>
+                    <TableCell align="right">남은 재고</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  <TableRow>
+                    <TableCell>상품 자체</TableCell>
+                    <TableCell align="right">{existing.stock === 0 ? "무한대" : existing.stock.toLocaleString()}</TableCell>
+                    <TableCell align="right">{formatLeftover(existing.leftover_stock)}</TableCell>
+                  </TableRow>
+                  {existing.tag_set.map((tagId) => {
+                    const tag = tags.find((t) => t.id === tagId);
+                    if (!tag) return null;
+                    return (
+                      <TableRow key={`tag-${tagId}`}>
+                        <TableCell>태그: {tag.name_ko || tag.name_en}</TableCell>
+                        <TableCell align="right">{tag.stock === 0 ? "무한대" : tag.stock.toLocaleString()}</TableCell>
+                        <TableCell align="right">{formatLeftover(tag.leftover_stock)}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  {existing.option_groups.flatMap((og) =>
+                    og.options.map((opt) => (
+                      <TableRow key={`opt-${opt.id}`}>
+                        <TableCell>
+                          옵션: {og.name_ko} &gt; {opt.name_ko}
+                        </TableCell>
+                        <TableCell align="right">{opt.stock === 0 ? "무한대" : opt.stock.toLocaleString()}</TableCell>
+                        <TableCell align="right">{formatLeftover(opt.leftover_stock)}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                  <TableRow sx={{ "& td": { fontWeight: 600, borderTop: 2, borderColor: "divider" } }}>
+                    <TableCell>현재 판매 가능 재고</TableCell>
+                    <TableCell align="right" colSpan={2}>
+                      {existing.leftover_stock === undefined ? (
+                        <Typography component="span" variant="body2" color="text.secondary">
+                          백엔드 leftover_stock 노출 후 표시
+                        </Typography>
+                      ) : existing.leftover_stock === null ? (
+                        "무한대"
+                      ) : (
+                        existing.leftover_stock.toLocaleString()
+                      )}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Box>
+
+            <Divider />
+          </Stack>
+        )}
+
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab label="기본 정보" />
+          <Tab label="시간 설정" />
+          <Tab label="가격 옵션" />
+          {existing && <Tab label="옵션 그룹" />}
+        </Tabs>
+
+        {tab === 0 && <BasicInfoTab values={values} setField={setField} disabled={disabled} groups={groups} tags={tags} />}
+        {tab === 1 && <TimeSettingsTab values={values} setField={setField} />}
+        {tab === 2 && <PriceOptionsTab values={values} setField={setField} />}
+        {tab === 3 && existing && <OptionGroupsTab productId={existing.id} optionGroups={existing.option_groups ?? []} />}
+
+        <Stack direction="row" spacing={2} justifyContent="flex-end">
+          {existing ? (
+            <>
+              <Button variant="outlined" color="info" startIcon={<Add />} onClick={() => navigate("/shop/products/create")} disabled={disabled}>
+                새 객체 추가
+              </Button>
+              <Button variant="outlined" color="error" startIcon={<Delete />} onClick={onDelete} disabled={disabled}>
+                삭제
+              </Button>
+              <Button variant="contained" startIcon={<Edit />} onClick={onSubmit} disabled={disabled}>
+                수정
+              </Button>
+            </>
+          ) : (
+            <Button variant="contained" startIcon={<Add />} onClick={onSubmit} disabled={disabled}>
+              새 객체 추가
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+    );
+  })
+);
+
+export const ShopProductEditorPage: React.FC = () => (
+  <BackendAdminSignInGuard>
+    <InnerProductEditor />
+  </BackendAdminSignInGuard>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/product/form.ts
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/form.ts
@@ -1,0 +1,72 @@
+import { ProductAdmin } from "./types";
+
+export type ProductFormValues = {
+  name_ko: string;
+  name_en: string;
+  description_ko: string;
+  description_en: string;
+  image: string;
+  price: string;
+  stock: string;
+  hidden: boolean;
+  max_quantity_per_user: string;
+  category: string;
+  priority: string;
+  visible_starts_at: string;
+  visible_ends_at: string;
+  orderable_starts_at: string;
+  orderable_ends_at: string;
+  refundable_ends_at: string;
+  donation_allowed: boolean;
+  donation_min_price: string;
+  donation_max_price: string;
+  tag_set: string[];
+};
+
+export type SetField = <K extends keyof ProductFormValues>(key: K, value: ProductFormValues[K]) => void;
+
+export const buildDefaultFormValues = (existing?: ProductAdmin): ProductFormValues => ({
+  name_ko: existing?.name_ko ?? "",
+  name_en: existing?.name_en ?? "",
+  description_ko: existing?.description_ko ?? "",
+  description_en: existing?.description_en ?? "",
+  image: existing?.image ?? "",
+  price: existing ? String(existing.price) : "0",
+  stock: existing ? String(existing.stock) : "0",
+  hidden: existing?.hidden ?? false,
+  max_quantity_per_user: existing ? String(existing.max_quantity_per_user) : "0",
+  category: existing?.category ?? "",
+  priority: existing ? String(existing.priority) : "0",
+  visible_starts_at: existing?.visible_starts_at ?? "",
+  visible_ends_at: existing?.visible_ends_at ?? "",
+  orderable_starts_at: existing?.orderable_starts_at ?? "",
+  orderable_ends_at: existing?.orderable_ends_at ?? "",
+  refundable_ends_at: existing?.refundable_ends_at ?? "",
+  donation_allowed: existing?.donation_allowed ?? false,
+  donation_min_price: existing ? String(existing.donation_min_price) : "0",
+  donation_max_price: existing ? String(existing.donation_max_price) : "0",
+  tag_set: existing?.tag_set ?? [],
+});
+
+export const toPayload = (v: ProductFormValues) => ({
+  name_ko: v.name_ko,
+  name_en: v.name_en,
+  description_ko: v.description_ko,
+  description_en: v.description_en,
+  image: v.image,
+  price: Number(v.price) || 0,
+  stock: Number(v.stock) || 0,
+  hidden: v.hidden,
+  max_quantity_per_user: Number(v.max_quantity_per_user) || 0,
+  category: v.category,
+  priority: Number(v.priority) || 0,
+  visible_starts_at: v.visible_starts_at || null,
+  visible_ends_at: v.visible_ends_at || null,
+  orderable_starts_at: v.orderable_starts_at || null,
+  orderable_ends_at: v.orderable_ends_at || null,
+  refundable_ends_at: v.refundable_ends_at || null,
+  donation_allowed: v.donation_allowed,
+  donation_min_price: Number(v.donation_min_price) || 0,
+  donation_max_price: Number(v.donation_max_price) || 0,
+  tag_set: v.tag_set,
+});

--- a/apps/pyconkr-admin/src/components/pages/shop/product/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/list.tsx
@@ -1,0 +1,213 @@
+import { useBackendAdminClient, useListQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { Add, Delete, Edit } from "@mui/icons-material";
+import {
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import { useMutation } from "@tanstack/react-query";
+import * as React from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+
+import { CategoryGroupAdminWithCategories, ProductAdmin, ProductCurrentStatus } from "./types";
+import { addErrorSnackbar, addSnackbar } from "../../../../utils/snackbar";
+import { BackendAdminSignInGuard } from "../../../elements/admin_signin_guard";
+import { ErrorFallback } from "../../../elements/error_fallback";
+import { PRODUCT_STATUS_LABEL } from "../_common/status_labels";
+
+const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+const formatLeftoverStock = (leftover: number | null | undefined) => {
+  if (leftover === null || leftover === undefined) return "무한대";
+  return leftover.toLocaleString();
+};
+
+type StatusFilter = "all" | ProductCurrentStatus;
+
+const InnerProductList: React.FC = ErrorBoundary.with(
+  { fallback: ErrorFallback },
+  Suspense.with({ fallback: <CircularProgress /> }, () => {
+    const client = useBackendAdminClient();
+    const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const nameQuery = searchParams.get("name") ?? "";
+    const categoryGroupQuery = searchParams.get("category_group") ?? "";
+    const categoryQuery = searchParams.get("category") ?? "";
+    const statusQuery = (searchParams.get("status") ?? "all") as StatusFilter;
+
+    const apiParams: Record<string, string> = {};
+    if (nameQuery.trim()) apiParams.name = nameQuery.trim();
+    if (categoryGroupQuery) apiParams.category_group = categoryGroupQuery;
+    if (categoryQuery) apiParams.category = categoryQuery;
+    if (statusQuery !== "all") apiParams.status = statusQuery;
+
+    const productsQuery = useListQuery<ProductAdmin>(client, "shop", "products", apiParams);
+    const groupsQuery = useListQuery<CategoryGroupAdminWithCategories>(client, "shop", "category-groups", {});
+
+    const products = productsQuery.data ?? [];
+    const groups = React.useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
+
+    const categoryToGroup: Record<string, { groupId: string; groupName: string; categoryName: string }> = React.useMemo(() => {
+      const map: Record<string, { groupId: string; groupName: string; categoryName: string }> = {};
+      for (const g of groups) {
+        for (const c of g.categories ?? []) {
+          map[c.id] = { groupId: g.id, groupName: g.name, categoryName: c.name };
+        }
+      }
+      return map;
+    }, [groups]);
+
+    const updateParam = (key: string, value: string) => {
+      const next = new URLSearchParams(searchParams);
+      if (value) next.set(key, value);
+      else next.delete(key);
+      setSearchParams(next, { replace: true });
+    };
+
+    const deleteMutation = useMutation({
+      mutationFn: async (id: string) => client.delete<void>(`v1/admin-api/shop/products/${id}/`),
+      onSuccess: () => addSnackbar("상품을 삭제했습니다.", "success"),
+      onError: addErrorSnackbar,
+    });
+
+    const handleDelete = (id: string, name: string) => {
+      if (window.confirm(`'${name}' 상품을 삭제하시겠습니까?`)) {
+        deleteMutation.mutate(id);
+      }
+    };
+
+    return (
+      <Stack sx={{ flexGrow: 1, width: "100%", minHeight: "100%" }} spacing={2}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h5">SHOP &gt; PRODUCTS &gt; 목록</Typography>
+          <Button variant="contained" startIcon={<Add />} onClick={() => navigate("/shop/products/create")}>
+            새 상품 추가
+          </Button>
+        </Stack>
+
+        <Stack direction="row" spacing={2} flexWrap="wrap" alignItems="center">
+          <TextField size="small" label="이름 검색" value={nameQuery} onChange={(e) => updateParam("name", e.target.value)} sx={{ minWidth: 240 }} />
+          <Select
+            size="small"
+            value={categoryGroupQuery}
+            onChange={(e) => {
+              const next = new URLSearchParams(searchParams);
+              if (e.target.value) next.set("category_group", e.target.value);
+              else next.delete("category_group");
+              next.delete("category"); // 그룹 바꾸면 카테고리 선택 초기화
+              setSearchParams(next, { replace: true });
+            }}
+            displayEmpty
+            sx={{ minWidth: 200 }}
+          >
+            <MenuItem value="">전체 카테고리 그룹</MenuItem>
+            {groups.map((g) => (
+              <MenuItem key={g.id} value={g.id}>
+                {g.name}
+              </MenuItem>
+            ))}
+          </Select>
+          <Select size="small" value={categoryQuery} onChange={(e) => updateParam("category", e.target.value)} displayEmpty sx={{ minWidth: 200 }}>
+            <MenuItem value="">전체 카테고리</MenuItem>
+            {(categoryGroupQuery ? groups.filter((g) => g.id === categoryGroupQuery) : groups).flatMap((group) => [
+              <MenuItem key={`group-${group.id}`} disabled sx={{ fontWeight: 600, opacity: "0.8 !important" }}>
+                {group.name}
+              </MenuItem>,
+              ...(group.categories ?? []).map((c) => (
+                <MenuItem key={c.id} value={c.id} sx={{ pl: 4 }}>
+                  {c.name}
+                </MenuItem>
+              )),
+            ])}
+          </Select>
+          <Select
+            size="small"
+            value={statusQuery}
+            onChange={(e) => updateParam("status", e.target.value === "all" ? "" : e.target.value)}
+            sx={{ minWidth: 160 }}
+          >
+            <MenuItem value="all">전체 상태</MenuItem>
+            <MenuItem value="active">노출 중</MenuItem>
+            <MenuItem value="hidden">비공개</MenuItem>
+            <MenuItem value="out_of_visible_period">노출 기간 아님</MenuItem>
+            <MenuItem value="out_of_orderable_period">판매 기간 아님</MenuItem>
+          </Select>
+          <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
+            {products.length} 건
+          </Typography>
+        </Stack>
+
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: "30%" }}>이름</TableCell>
+              <TableCell>카테고리</TableCell>
+              <TableCell align="right">가격</TableCell>
+              <TableCell align="right">판매 가능 재고</TableCell>
+              <TableCell>상태</TableCell>
+              <TableCell sx={{ width: 120 }}>작업</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {products.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ color: "text.secondary" }}>
+                  조건에 맞는 상품이 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+            {products.map((product) => {
+              const cat = categoryToGroup[product.category];
+              const status = PRODUCT_STATUS_LABEL[product.current_status] ?? { label: product.current_status, color: "default" as const };
+              return (
+                <TableRow key={product.id} hover>
+                  <TableCell>
+                    <Link to={`/shop/products/${product.id}`}>{product.name_ko || product.str_repr}</Link>
+                  </TableCell>
+                  <TableCell>{cat ? `${cat.groupName} > ${cat.categoryName}` : "—"}</TableCell>
+                  <TableCell align="right">{formatPrice(product.price)}</TableCell>
+                  <TableCell align="right">{formatLeftoverStock(product.leftover_stock)}</TableCell>
+                  <TableCell>
+                    <Chip label={status.label} size="small" color={status.color} />
+                  </TableCell>
+                  <TableCell>
+                    <IconButton size="small" onClick={() => navigate(`/shop/products/${product.id}`)} aria-label="수정">
+                      <Edit fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => handleDelete(product.id, product.name_ko || product.str_repr)}
+                      aria-label="삭제"
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Stack>
+    );
+  })
+);
+
+export const ShopProductListPage: React.FC = () => (
+  <BackendAdminSignInGuard>
+    <InnerProductList />
+  </BackendAdminSignInGuard>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/product/tabs/basic_info_tab.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/tabs/basic_info_tab.tsx
@@ -1,0 +1,135 @@
+import { Components } from "@frontend/common";
+import { useCommonContext } from "@frontend/common/src/hooks/useCommonContext";
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControlLabel,
+  MenuItem,
+  Stack,
+  styled,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from "@mui/material";
+import * as React from "react";
+
+import { ProductFormValues, SetField } from "../form";
+import { CategoryGroupAdminWithCategories, TagAdmin } from "../types";
+
+const MUIStyledFieldset = styled("fieldset")(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  margin: 0,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
+}));
+
+const MDXRendererContainer = styled(Box)(({ theme }) => ({
+  width: "50%",
+  maxWidth: "50%",
+  "& .markdown-body": {
+    width: "100%",
+    p: { margin: theme.spacing(2, 0) },
+    a: { color: theme.palette.primary.main },
+  },
+}));
+
+type Props = {
+  values: ProductFormValues;
+  setField: SetField;
+  disabled?: boolean;
+  groups: CategoryGroupAdminWithCategories[];
+  tags: TagAdmin[];
+};
+
+export const BasicInfoTab: React.FC<Props> = ({ values, setField, disabled, groups, tags }) => {
+  const [langTab, setLangTab] = React.useState<"ko" | "en">("ko");
+  const { baseUrl, mdxComponents } = useCommonContext();
+  const selectedTags = tags.filter((t) => values.tag_set.includes(t.id));
+  const isKo = langTab === "ko";
+  const nameKey = isKo ? "name_ko" : "name_en";
+  const descKey = isKo ? "description_ko" : "description_en";
+
+  return (
+    <Stack spacing={2}>
+      <TextField select label="카테고리" required value={values.category} onChange={(e) => setField("category", e.target.value)} fullWidth>
+        {groups.flatMap((group) => [
+          <MenuItem key={`group-${group.id}`} disabled sx={{ fontWeight: 600, opacity: "0.8 !important" }}>
+            {group.name}
+          </MenuItem>,
+          ...(group.categories ?? []).map((c) => (
+            <MenuItem key={c.id} value={c.id} sx={{ pl: 4 }}>
+              {c.name}
+            </MenuItem>
+          )),
+        ])}
+      </TextField>
+
+      <Autocomplete
+        multiple
+        options={tags}
+        getOptionLabel={(t) => t.name_ko || t.name_en || t.id}
+        value={selectedTags}
+        onChange={(_, newValue) =>
+          setField(
+            "tag_set",
+            newValue.map((t) => t.id)
+          )
+        }
+        renderValue={(value, getItemProps) =>
+          value.map((option, index) => {
+            const { key, ...rest } = getItemProps({ index });
+            return <Chip key={key} {...rest} label={option.name_ko || option.name_en || option.id} />;
+          })
+        }
+        renderInput={(params) => (
+          <TextField {...params} label="태그" placeholder="태그를 선택하세요" helperText="태그는 별도 페이지에서 생성/수정할 수 있습니다." />
+        )}
+      />
+
+      <FormControlLabel
+        control={<Checkbox checked={values.hidden} onChange={(e) => setField("hidden", e.target.checked)} />}
+        label="비공개 (사용자에게 노출되지 않음)"
+      />
+
+      <Divider />
+
+      <Stack direction="row" spacing={2}>
+        <Tabs orientation="vertical" value={langTab} onChange={(_, v) => setLangTab(v)} scrollButtons={false}>
+          <Tab value="ko" label="한국어" />
+          <Tab value="en" label="영어" />
+        </Tabs>
+        <Stack direction="column" spacing={2} sx={{ width: "100%", maxWidth: "100%" }}>
+          <TextField
+            label={isKo ? "이름 (한국어)" : "이름 (영어)"}
+            required
+            value={values[nameKey]}
+            onChange={(e) => setField(nameKey, e.target.value)}
+            fullWidth
+          />
+          <MUIStyledFieldset>
+            <Typography variant="subtitle2" component="legend">
+              상품 설명 {isKo ? "(한국어)" : "(영어)"}
+            </Typography>
+            <Stack direction="row" spacing={2}>
+              <Box sx={{ width: "50%", maxWidth: "50%" }}>
+                <Components.MarkdownEditor
+                  disabled={disabled}
+                  name={descKey}
+                  value={values[descKey]}
+                  onChange={(value) => setField(descKey, value ?? "")}
+                />
+              </Box>
+              <MDXRendererContainer>
+                <Components.MDXRenderer text={values[descKey]} format="mdx" baseUrl={baseUrl} mdxComponents={mdxComponents} />
+              </MDXRendererContainer>
+            </Stack>
+          </MUIStyledFieldset>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/product/tabs/basic_info_tab.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/tabs/basic_info_tab.tsx
@@ -17,6 +17,8 @@ import {
 } from "@mui/material";
 import * as React from "react";
 
+import { IMAGE_FILE_EXTENSIONS } from "../../../../../consts/file_extensions";
+import { PublicFilePicker } from "../../../../elements/public_file_picker";
 import { ProductFormValues, SetField } from "../form";
 import { CategoryGroupAdminWithCategories, TagAdmin } from "../types";
 
@@ -55,6 +57,16 @@ export const BasicInfoTab: React.FC<Props> = ({ values, setField, disabled, grou
 
   return (
     <Stack spacing={2}>
+      <PublicFilePicker
+        label="대표 이미지"
+        value={values.image}
+        onChange={(v) => setField("image", v)}
+        choicesApp="shop"
+        choicesResource="products"
+        choicesField="image"
+        acceptExtensions={IMAGE_FILE_EXTENSIONS}
+      />
+
       <TextField select label="카테고리" required value={values.category} onChange={(e) => setField("category", e.target.value)} fullWidth>
         {groups.flatMap((group) => [
           <MenuItem key={`group-${group.id}`} disabled sx={{ fontWeight: 600, opacity: "0.8 !important" }}>

--- a/apps/pyconkr-admin/src/components/pages/shop/product/tabs/option_groups_tab.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/tabs/option_groups_tab.tsx
@@ -1,0 +1,497 @@
+import { useBackendAdminClient, useCreateMutation, useUpdateMutation } from "@frontend/common/src/hooks/useAdminAPI";
+import { Add, Delete, Edit, ExpandMore } from "@mui/icons-material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useMutation } from "@tanstack/react-query";
+import * as React from "react";
+
+import { addErrorSnackbar, addSnackbar } from "../../../../../utils/snackbar";
+import { OptionAdmin, OptionGroupAdmin } from "../types";
+
+// ----------------- Option dialog -----------------
+type OptionFormValues = {
+  name_ko: string;
+  name_en: string;
+  additional_price: string;
+  stock: string;
+  max_quantity_per_user: string;
+  priority: string;
+};
+
+type OptionDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  optionGroup: OptionGroupAdmin;
+  option?: OptionAdmin;
+};
+
+const OptionDialog: React.FC<OptionDialogProps> = ({ open, onClose, optionGroup, option }) => {
+  const client = useBackendAdminClient();
+  const updateMutation = useUpdateMutation<OptionGroupAdmin>(client, "shop", "option-groups", optionGroup.id);
+  const [values, setValues] = React.useState<OptionFormValues>({
+    name_ko: "",
+    name_en: "",
+    additional_price: "0",
+    stock: "0",
+    max_quantity_per_user: "0",
+    priority: "0",
+  });
+
+  React.useEffect(() => {
+    if (open) {
+      setValues({
+        name_ko: option?.name_ko ?? "",
+        name_en: option?.name_en ?? "",
+        additional_price: option ? String(option.additional_price) : "0",
+        stock: option ? String(option.stock) : "0",
+        max_quantity_per_user: option ? String(option.max_quantity_per_user) : "0",
+        priority: option ? String(option.priority) : String(optionGroup.options.length * 10),
+      });
+    }
+  }, [open, option, optionGroup.options.length]);
+
+  const onSubmit = () => {
+    if (!values.name_ko.trim()) {
+      addSnackbar("한국어 이름은 필수입니다.", "error");
+      return;
+    }
+    if (!values.name_en.trim()) {
+      addSnackbar("영어 이름은 필수입니다.", "error");
+      return;
+    }
+    const optionPayload = {
+      name_ko: values.name_ko,
+      name_en: values.name_en,
+      additional_price: Number(values.additional_price) || 0,
+      stock: Number(values.stock) || 0,
+      max_quantity_per_user: Number(values.max_quantity_per_user) || 0,
+      priority: Number(values.priority) || 0,
+      group: optionGroup.id,
+    };
+    const newOptions = option
+      ? optionGroup.options.map((o) => (o.id === option.id ? { ...o, ...optionPayload } : o))
+      : [...optionGroup.options, optionPayload];
+    updateMutation.mutate({ ...optionGroup, options: newOptions } as unknown as OptionGroupAdmin, {
+      onSuccess: () => {
+        addSnackbar(`옵션 '${values.name_ko}'을(를) ${option ? "수정" : "생성"}했습니다.`, "success");
+        onClose();
+      },
+      onError: addErrorSnackbar,
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={updateMutation.isPending ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{option ? `옵션 수정: ${option.name_ko}` : "새 옵션 추가"}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="이름 (한국어)"
+              required
+              value={values.name_ko}
+              onChange={(e) => setValues((p) => ({ ...p, name_ko: e.target.value }))}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              label="이름 (영어)"
+              required
+              value={values.name_en}
+              onChange={(e) => setValues((p) => ({ ...p, name_en: e.target.value }))}
+              fullWidth
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="추가 금액"
+              type="number"
+              value={values.additional_price}
+              onChange={(e) => setValues((p) => ({ ...p, additional_price: e.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="우선순위"
+              type="number"
+              value={values.priority}
+              onChange={(e) => setValues((p) => ({ ...p, priority: e.target.value }))}
+              fullWidth
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="재고 (0 = 무한대)"
+              type="number"
+              value={values.stock}
+              onChange={(e) => setValues((p) => ({ ...p, stock: e.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="사용자당 최대 (0 = 제한 없음)"
+              type="number"
+              value={values.max_quantity_per_user}
+              onChange={(e) => setValues((p) => ({ ...p, max_quantity_per_user: e.target.value }))}
+              fullWidth
+            />
+          </Stack>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={updateMutation.isPending}>
+          취소
+        </Button>
+        <Button variant="contained" onClick={onSubmit} disabled={updateMutation.isPending}>
+          {option ? "수정" : "추가"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// ----------------- OptionGroup dialog -----------------
+type OptionGroupFormValues = {
+  name_ko: string;
+  name_en: string;
+  min_quantity_per_product: string;
+  max_quantity_per_product: string;
+  is_custom_response: boolean;
+  custom_response_pattern: string;
+  priority: string;
+  response_modifiable_ends_at: string;
+};
+
+type OptionGroupDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  productId: string;
+  group?: OptionGroupAdmin;
+  existingGroupCount: number;
+};
+
+const OptionGroupDialog: React.FC<OptionGroupDialogProps> = ({ open, onClose, productId, group, existingGroupCount }) => {
+  const client = useBackendAdminClient();
+  const createMutation = useCreateMutation<OptionGroupAdmin>(client, "shop", "option-groups");
+  const updateMutation = useUpdateMutation<OptionGroupAdmin>(client, "shop", "option-groups", group?.id ?? "");
+
+  const [values, setValues] = React.useState<OptionGroupFormValues>({
+    name_ko: "",
+    name_en: "",
+    min_quantity_per_product: "0",
+    max_quantity_per_product: "1",
+    is_custom_response: false,
+    custom_response_pattern: "",
+    priority: "0",
+    response_modifiable_ends_at: "",
+  });
+
+  React.useEffect(() => {
+    if (open) {
+      setValues({
+        name_ko: group?.name_ko ?? "",
+        name_en: group?.name_en ?? "",
+        min_quantity_per_product: group ? String(group.min_quantity_per_product) : "0",
+        max_quantity_per_product: group ? String(group.max_quantity_per_product) : "1",
+        is_custom_response: group?.is_custom_response ?? false,
+        custom_response_pattern: group?.custom_response_pattern ?? "",
+        priority: group ? String(group.priority) : String(existingGroupCount * 10),
+        response_modifiable_ends_at: group?.response_modifiable_ends_at ?? "",
+      });
+    }
+  }, [open, group, existingGroupCount]);
+
+  const onSubmit = () => {
+    if (!values.name_ko.trim()) {
+      addSnackbar("한국어 이름은 필수입니다.", "error");
+      return;
+    }
+    if (!values.name_en.trim()) {
+      addSnackbar("영어 이름은 필수입니다.", "error");
+      return;
+    }
+
+    const payload = {
+      product: productId,
+      priority: Number(values.priority) || 0,
+      name_ko: values.name_ko,
+      name_en: values.name_en,
+      min_quantity_per_product: Number(values.min_quantity_per_product) || 0,
+      max_quantity_per_product: Number(values.max_quantity_per_product) || 1,
+      is_custom_response: values.is_custom_response,
+      custom_response_pattern: values.is_custom_response ? values.custom_response_pattern : "",
+      response_modifiable_ends_at: values.response_modifiable_ends_at || null,
+      options: group?.options ?? [],
+    };
+
+    const handlers = {
+      onSuccess: () => {
+        addSnackbar(`옵션 그룹 '${values.name_ko}'을(를) ${group ? "수정" : "생성"}했습니다.`, "success");
+        onClose();
+      },
+      onError: addErrorSnackbar,
+    };
+
+    if (group) updateMutation.mutate(payload as unknown as OptionGroupAdmin, handlers);
+    else createMutation.mutate(payload as unknown as OptionGroupAdmin, handlers);
+  };
+
+  const pending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={open} onClose={pending ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{group ? `옵션 그룹 수정: ${group.name_ko}` : "새 옵션 그룹 추가"}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="이름 (한국어)"
+              required
+              value={values.name_ko}
+              onChange={(e) => setValues((p) => ({ ...p, name_ko: e.target.value }))}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              label="이름 (영어)"
+              required
+              value={values.name_en}
+              onChange={(e) => setValues((p) => ({ ...p, name_en: e.target.value }))}
+              fullWidth
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="상품당 최소 수량"
+              type="number"
+              value={values.min_quantity_per_product}
+              onChange={(e) => setValues((p) => ({ ...p, min_quantity_per_product: e.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="상품당 최대 수량"
+              type="number"
+              value={values.max_quantity_per_product}
+              onChange={(e) => setValues((p) => ({ ...p, max_quantity_per_product: e.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="우선순위"
+              type="number"
+              value={values.priority}
+              onChange={(e) => setValues((p) => ({ ...p, priority: e.target.value }))}
+              fullWidth
+            />
+          </Stack>
+          <FormControlLabel
+            control={
+              <Checkbox checked={values.is_custom_response} onChange={(e) => setValues((p) => ({ ...p, is_custom_response: e.target.checked }))} />
+            }
+            label="사용자 입력 옵션 (custom response)"
+          />
+          {values.is_custom_response && (
+            <TextField
+              label="입력 검증 정규식"
+              value={values.custom_response_pattern}
+              onChange={(e) => setValues((p) => ({ ...p, custom_response_pattern: e.target.value }))}
+              fullWidth
+              helperText="예: ^.{1,20}$"
+            />
+          )}
+          <TextField
+            label="응답 수정 가능 종료"
+            type="datetime-local"
+            value={values.response_modifiable_ends_at?.slice(0, 16) ?? ""}
+            onChange={(e) => setValues((p) => ({ ...p, response_modifiable_ends_at: e.target.value }))}
+            fullWidth
+            slotProps={{ inputLabel: { shrink: true } }}
+            helperText="비워두면 제한 없음"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={pending}>
+          취소
+        </Button>
+        <Button variant="contained" onClick={onSubmit} disabled={pending}>
+          {group ? "수정" : "추가"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// ----------------- Tab component -----------------
+type Props = {
+  productId: string;
+  optionGroups: OptionGroupAdmin[];
+};
+
+export const OptionGroupsTab: React.FC<Props> = ({ productId, optionGroups }) => {
+  const client = useBackendAdminClient();
+  const [groupDialog, setGroupDialog] = React.useState<{ open: boolean; group?: OptionGroupAdmin }>({ open: false });
+  const [optionDialog, setOptionDialog] = React.useState<{ open: boolean; optionGroup?: OptionGroupAdmin; option?: OptionAdmin }>({ open: false });
+
+  const deleteGroupMutation = useMutation({
+    mutationFn: async (groupId: string) => client.delete<void>(`v1/admin-api/shop/option-groups/${groupId}/`),
+    onSuccess: () => addSnackbar("옵션 그룹을 삭제했습니다.", "success"),
+    onError: addErrorSnackbar,
+  });
+
+  const deleteOptionMutation = useMutation({
+    mutationFn: async (params: { group: OptionGroupAdmin; optionId: string }) => {
+      const newOptions = params.group.options.filter((o) => o.id !== params.optionId);
+      return client.patch(`v1/admin-api/shop/option-groups/${params.group.id}/`, { ...params.group, options: newOptions });
+    },
+    onSuccess: () => addSnackbar("옵션을 삭제했습니다.", "success"),
+    onError: addErrorSnackbar,
+  });
+
+  const handleDeleteGroup = (group: OptionGroupAdmin) => {
+    if (window.confirm(`'${group.name_ko}' 옵션 그룹을 삭제하시겠습니까? 하위 옵션도 함께 삭제됩니다.`)) {
+      deleteGroupMutation.mutate(group.id);
+    }
+  };
+
+  const handleDeleteOption = (group: OptionGroupAdmin, option: OptionAdmin) => {
+    if (window.confirm(`'${option.name_ko}' 옵션을 삭제하시겠습니까?`)) {
+      deleteOptionMutation.mutate({ group, optionId: option.id });
+    }
+  };
+
+  const sortedGroups = [...optionGroups].sort((a, b) => a.priority - b.priority);
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="h6">옵션 그룹 ({sortedGroups.length})</Typography>
+        <Button size="small" variant="outlined" startIcon={<Add />} onClick={() => setGroupDialog({ open: true })}>
+          옵션 그룹 추가
+        </Button>
+      </Stack>
+
+      {sortedGroups.length === 0 && (
+        <Typography color="text.secondary" sx={{ py: 2 }}>
+          옵션 그룹이 없습니다.
+        </Typography>
+      )}
+
+      {sortedGroups.map((group) => {
+        const options = [...group.options].sort((a, b) => a.priority - b.priority);
+        return (
+          <Accordion key={group.id} defaultExpanded>
+            <AccordionSummary expandIcon={<ExpandMore />}>
+              <Stack direction="row" spacing={2} alignItems="center" sx={{ width: "100%", pr: 2 }}>
+                <Typography sx={{ fontWeight: 500 }}>{group.name_ko}</Typography>
+                {group.is_custom_response && <Chip label="사용자 입력" size="small" />}
+                <Box sx={{ flexGrow: 1 }} />
+                <Typography variant="caption" color="text.secondary">
+                  최소 {group.min_quantity_per_product} / 최대 {group.max_quantity_per_product} · 옵션 {options.length}개
+                </Typography>
+              </Stack>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Stack spacing={1}>
+                <Stack direction="row" spacing={1} justifyContent="flex-end">
+                  {!group.is_custom_response && (
+                    <Button size="small" startIcon={<Add />} onClick={() => setOptionDialog({ open: true, optionGroup: group })}>
+                      옵션 추가
+                    </Button>
+                  )}
+                  <Button size="small" startIcon={<Edit />} onClick={() => setGroupDialog({ open: true, group })}>
+                    그룹 수정
+                  </Button>
+                  <Button size="small" color="error" startIcon={<Delete />} onClick={() => handleDeleteGroup(group)}>
+                    그룹 삭제
+                  </Button>
+                </Stack>
+                {group.is_custom_response ? (
+                  <Alert severity="info" variant="outlined">
+                    이 그룹은 사용자 입력형이며, 옵션이 없습니다. 검증 정규식: <code>{group.custom_response_pattern || "(없음)"}</code>
+                  </Alert>
+                ) : (
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell sx={{ width: "35%" }}>이름</TableCell>
+                        <TableCell align="right">추가 금액</TableCell>
+                        <TableCell align="right">재고</TableCell>
+                        <TableCell align="right">사용자당 최대</TableCell>
+                        <TableCell align="right">우선순위</TableCell>
+                        <TableCell sx={{ width: 100 }}>작업</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {options.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={6} align="center" sx={{ color: "text.secondary" }}>
+                            옵션이 없습니다.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                      {options.map((option) => (
+                        <TableRow key={option.id} hover>
+                          <TableCell>{option.name_ko}</TableCell>
+                          <TableCell align="right">₩{option.additional_price.toLocaleString()}</TableCell>
+                          <TableCell align="right">{option.stock === 0 ? "무한대" : option.stock.toLocaleString()}</TableCell>
+                          <TableCell align="right">
+                            {option.max_quantity_per_user === 0 ? "제한 없음" : option.max_quantity_per_user.toLocaleString()}
+                          </TableCell>
+                          <TableCell align="right">{option.priority}</TableCell>
+                          <TableCell>
+                            <IconButton size="small" onClick={() => setOptionDialog({ open: true, optionGroup: group, option })} aria-label="수정">
+                              <Edit fontSize="small" />
+                            </IconButton>
+                            <IconButton size="small" color="error" onClick={() => handleDeleteOption(group, option)} aria-label="삭제">
+                              <Delete fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+
+      <OptionGroupDialog
+        open={groupDialog.open}
+        onClose={() => setGroupDialog({ open: false })}
+        productId={productId}
+        group={groupDialog.group}
+        existingGroupCount={sortedGroups.length}
+      />
+      {optionDialog.optionGroup && (
+        <OptionDialog
+          open={optionDialog.open}
+          onClose={() => setOptionDialog({ open: false })}
+          optionGroup={optionDialog.optionGroup}
+          option={optionDialog.option}
+        />
+      )}
+    </Stack>
+  );
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/product/tabs/price_options_tab.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/tabs/price_options_tab.tsx
@@ -1,0 +1,56 @@
+import { Checkbox, Divider, FormControlLabel, Stack, TextField } from "@mui/material";
+import * as React from "react";
+
+import { ProductFormValues, SetField } from "../form";
+
+type Props = {
+  values: ProductFormValues;
+  setField: SetField;
+};
+
+export const PriceOptionsTab: React.FC<Props> = ({ values, setField }) => (
+  <Stack spacing={2}>
+    <Stack direction="row" spacing={2}>
+      <TextField label="가격 (₩)" type="number" required value={values.price} onChange={(e) => setField("price", e.target.value)} fullWidth />
+      <TextField
+        label="재고 (0 = 무한대)"
+        type="number"
+        required
+        value={values.stock}
+        onChange={(e) => setField("stock", e.target.value)}
+        fullWidth
+      />
+      <TextField
+        label="사용자당 최대 수량 (0 = 제한 없음)"
+        type="number"
+        value={values.max_quantity_per_user}
+        onChange={(e) => setField("max_quantity_per_user", e.target.value)}
+        fullWidth
+      />
+      <TextField label="우선순위" type="number" value={values.priority} onChange={(e) => setField("priority", e.target.value)} fullWidth />
+    </Stack>
+    <Divider />
+    <FormControlLabel
+      control={<Checkbox checked={values.donation_allowed} onChange={(e) => setField("donation_allowed", e.target.checked)} />}
+      label="기부 허용"
+    />
+    {values.donation_allowed && (
+      <Stack direction="row" spacing={2}>
+        <TextField
+          label="기부 최소 금액"
+          type="number"
+          value={values.donation_min_price}
+          onChange={(e) => setField("donation_min_price", e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="기부 최대 금액"
+          type="number"
+          value={values.donation_max_price}
+          onChange={(e) => setField("donation_max_price", e.target.value)}
+          fullWidth
+        />
+      </Stack>
+    )}
+  </Stack>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/product/tabs/time_settings_tab.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/tabs/time_settings_tab.tsx
@@ -1,0 +1,37 @@
+import { Stack, TextField, Typography } from "@mui/material";
+import * as React from "react";
+
+import { ProductFormValues, SetField } from "../form";
+
+type Props = {
+  values: ProductFormValues;
+  setField: SetField;
+};
+
+type DateTimeFieldKey = "visible_starts_at" | "visible_ends_at" | "orderable_starts_at" | "orderable_ends_at" | "refundable_ends_at";
+
+const dateTimeFieldProps = (values: ProductFormValues, setField: SetField, key: DateTimeFieldKey, label: string) => ({
+  label,
+  type: "datetime-local" as const,
+  value: values[key]?.slice(0, 16) ?? "",
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => setField(key, e.target.value),
+  fullWidth: true,
+  slotProps: { inputLabel: { shrink: true } },
+});
+
+export const TimeSettingsTab: React.FC<Props> = ({ values, setField }) => (
+  <Stack spacing={2}>
+    <Typography variant="subtitle2" color="text.secondary">
+      비워두면 항상 활성으로 처리됩니다.
+    </Typography>
+    <Stack direction="row" spacing={2}>
+      <TextField {...dateTimeFieldProps(values, setField, "visible_starts_at", "노출 시작")} />
+      <TextField {...dateTimeFieldProps(values, setField, "visible_ends_at", "노출 종료")} />
+    </Stack>
+    <Stack direction="row" spacing={2}>
+      <TextField {...dateTimeFieldProps(values, setField, "orderable_starts_at", "주문 가능 시작")} />
+      <TextField {...dateTimeFieldProps(values, setField, "orderable_ends_at", "주문 가능 종료")} />
+    </Stack>
+    <TextField {...dateTimeFieldProps(values, setField, "refundable_ends_at", "환불 가능 종료")} />
+  </Stack>
+);

--- a/apps/pyconkr-admin/src/components/pages/shop/product/types.ts
+++ b/apps/pyconkr-admin/src/components/pages/shop/product/types.ts
@@ -1,0 +1,85 @@
+export type OptionAdmin = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  group: string;
+  priority: number;
+  name_ko: string;
+  name_en: string;
+  max_quantity_per_user: number;
+  additional_price: number;
+  stock: number;
+  leftover_stock?: number | null;
+};
+
+export type OptionGroupAdmin = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  str_repr: string;
+  product: string;
+  priority: number;
+  name_ko: string;
+  name_en: string;
+  min_quantity_per_product: number;
+  max_quantity_per_product: number;
+  is_custom_response: boolean;
+  custom_response_pattern: string;
+  response_modifiable_ends_at: string | null;
+  options: OptionAdmin[];
+};
+
+export type ProductAdmin = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  str_repr: string;
+  name_ko: string;
+  name_en: string;
+  description_ko: string;
+  description_en: string;
+  image: string;
+  price: number;
+  stock: number;
+  hidden: boolean;
+  max_quantity_per_user: number;
+  visible_starts_at: string;
+  visible_ends_at: string;
+  orderable_starts_at: string;
+  orderable_ends_at: string;
+  refundable_ends_at: string;
+  category: string;
+  priority: number;
+  donation_allowed: boolean;
+  donation_min_price: number;
+  donation_max_price: number;
+  option_groups: OptionGroupAdmin[];
+  tag_set: string[];
+  leftover_stock?: number | null;
+  current_status: ProductCurrentStatus;
+};
+
+export type ProductCurrentStatus = "hidden" | "out_of_visible_period" | "out_of_orderable_period" | "active";
+
+export type TagAdmin = {
+  id: string;
+  name_ko: string;
+  name_en: string;
+  stock: number;
+  max_quantity_per_user: number;
+  leftover_stock?: number | null;
+};
+
+export type CategoryAdminFromGroup = {
+  id: string;
+  name: string;
+  priority: number;
+  group: string;
+};
+
+export type CategoryGroupAdminWithCategories = {
+  id: string;
+  name: string;
+  priority: number;
+  categories: CategoryAdminFromGroup[];
+};

--- a/apps/pyconkr-admin/src/components/pages/shop/tag/list.tsx
+++ b/apps/pyconkr-admin/src/components/pages/shop/tag/list.tsx
@@ -1,0 +1,51 @@
+import { Chip } from "@mui/material";
+import * as React from "react";
+import { Link } from "react-router-dom";
+
+import { AdminList, AdminListColumn } from "../../../layouts/admin_list";
+
+const formatStock = (stock: number) => (stock === 0 ? "무한대" : stock.toLocaleString());
+const formatMaxPerUser = (qty: number) => (qty === 0 ? "제한 없음" : qty.toLocaleString());
+
+const columns: AdminListColumn[] = [
+  {
+    field: "name_ko",
+    header: "이름",
+    width: "30%",
+    render: (row) => {
+      const id = row.id as string;
+      const name = String(row.name_ko ?? row.name_en ?? "");
+      const leftover = row.leftover_stock;
+      const soldOut = typeof leftover === "number" && leftover <= 0;
+      return (
+        <>
+          <Link to={`/shop/tags/${id}`}>{name}</Link>
+          {soldOut && <Chip label="매진" size="small" color="error" sx={{ ml: 1 }} />}
+        </>
+      );
+    },
+  },
+  {
+    field: "stock",
+    header: "재고",
+    align: "right",
+    render: (row) => formatStock(Number(row.stock ?? 0)),
+  },
+  {
+    field: "max_quantity_per_user",
+    header: "사용자당 최대 수량",
+    align: "right",
+    render: (row) => formatMaxPerUser(Number(row.max_quantity_per_user ?? 0)),
+  },
+  {
+    field: "leftover_stock",
+    header: "남은 재고",
+    align: "right",
+    render: (row) => {
+      const v = row.leftover_stock;
+      return v === null || v === undefined ? "—" : Number(v).toLocaleString();
+    },
+  },
+];
+
+export const ShopTagListPage: React.FC = () => <AdminList app="shop" resource="tags" columns={columns} enableRowActions />;

--- a/apps/pyconkr-admin/src/components/pages/user/editor.tsx
+++ b/apps/pyconkr-admin/src/components/pages/user/editor.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { PasswordResultDialog } from "./password_result_dialog";
+import { ShopOrderSection } from "./shop_order_section";
 import { addErrorSnackbar } from "../../../utils/snackbar";
 import { ErrorFallback } from "../../elements/error_fallback";
 import { AdminEditor } from "../../layouts/admin_editor";
@@ -90,7 +91,10 @@ export const AdminUserExtEditor: React.FC = ErrorBoundary.with(
 
         <PasswordResultDialog open={pageState.isResultDialogOpen} password={pageState.newPassword} onClose={closeResultDialog} />
 
-        <AdminEditor app="user" resource="userext" id={id} extraActions={[resetUserPasswordButton]} onCreated={onCreated} />
+        <AdminEditor app="user" resource="userext" id={id} extraActions={[resetUserPasswordButton]} onCreated={onCreated}>
+          {id && <ShopOrderSection userId={id} />}
+          <br />
+        </AdminEditor>
       </>
     );
   })

--- a/apps/pyconkr-admin/src/components/pages/user/shop_order_section.tsx
+++ b/apps/pyconkr-admin/src/components/pages/user/shop_order_section.tsx
@@ -1,0 +1,84 @@
+import { useBackendAdminClient, useListQuery } from "@frontend/common/src/hooks/useAdminAPI";
+import { Alert, Chip, CircularProgress, Divider, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
+import * as React from "react";
+import { Link } from "react-router-dom";
+
+import { ErrorFallback } from "../../elements/error_fallback";
+import { PAYMENT_STATUS_LABEL } from "../shop/_common/status_labels";
+import { PaymentStatus } from "../shop/order/types";
+
+type OrderListRow = {
+  id: string;
+  str_repr: string;
+  name_ko: string;
+  current_status: PaymentStatus;
+  current_paid_price: number;
+  first_paid_at: string | null;
+  created_at: string;
+};
+
+const formatPrice = (price: number) => `₩${price.toLocaleString()}`;
+
+const InnerShopOrderSection: React.FC<{ userId: string }> = ErrorBoundary.with(
+  { fallback: ErrorFallback },
+  Suspense.with({ fallback: <CircularProgress /> }, ({ userId }) => {
+    const client = useBackendAdminClient();
+    const ordersQuery = useListQuery<OrderListRow>(client, "shop", "orders", { user_id: userId });
+    const orders = ordersQuery.data ?? [];
+
+    return (
+      <Stack spacing={2} sx={{ mt: 4 }}>
+        <Divider />
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">스토어 주문 내역 ({orders.length})</Typography>
+        </Stack>
+        <Alert severity="info" variant="outlined">
+          이 사용자의 모든 스토어 주문입니다. 환불·알림 등 액션은 주문 상세 페이지에서 수행할 수 있습니다.
+        </Alert>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: "15%" }}>주문 ID</TableCell>
+              <TableCell>이름</TableCell>
+              <TableCell>상태</TableCell>
+              <TableCell align="right">결제액</TableCell>
+              <TableCell>결제일</TableCell>
+              <TableCell>생성일</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {orders.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ color: "text.secondary" }}>
+                  주문 내역이 없습니다.
+                </TableCell>
+              </TableRow>
+            )}
+            {orders.map((order) => {
+              const status = PAYMENT_STATUS_LABEL[order.current_status] ?? { label: order.current_status, color: "default" as const };
+              return (
+                <TableRow key={order.id} hover>
+                  <TableCell>
+                    <Link to={`/shop/orders/${order.id}`}>
+                      <code>{order.id.slice(0, 8)}</code>
+                    </Link>
+                  </TableCell>
+                  <TableCell>{order.name_ko || order.str_repr}</TableCell>
+                  <TableCell>
+                    <Chip label={status.label} size="small" color={status.color} />
+                  </TableCell>
+                  <TableCell align="right">{formatPrice(order.current_paid_price)}</TableCell>
+                  <TableCell>{order.first_paid_at ? new Date(order.first_paid_at).toLocaleString() : "—"}</TableCell>
+                  <TableCell>{new Date(order.created_at).toLocaleString()}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Stack>
+    );
+  })
+);
+
+export const ShopOrderSection: React.FC<{ userId: string }> = (props) => <InnerShopOrderSection {...props} />;

--- a/apps/pyconkr-admin/src/consts/file_extensions.ts
+++ b/apps/pyconkr-admin/src/consts/file_extensions.ts
@@ -1,0 +1,1 @@
+export const IMAGE_FILE_EXTENSIONS = ["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "avif"];

--- a/apps/pyconkr-admin/src/routes.tsx
+++ b/apps/pyconkr-admin/src/routes.tsx
@@ -10,14 +10,18 @@ import {
   Email,
   Event,
   FilePresent,
+  FolderSpecial,
   Forum,
   Handshake,
+  LocalOffer,
   ManageAccounts,
   MarkEmailRead,
   MeetingRoom,
   NoteAlt,
   Public,
+  ReceiptLong,
   Send,
+  ShoppingBag,
   Sms,
   StickyNote2,
   Tag,
@@ -41,6 +45,13 @@ import { AdminNotificationHistoryEditor } from "./components/pages/notification/
 import { AdminSMSTemplateEditor } from "./components/pages/notification/sms_template_editor";
 import { AdminCMSPageEditor } from "./components/pages/page/editor";
 import { AdminPresentationEditor } from "./components/pages/presentation/editor";
+import { ShopCategoryGroupEditorPage } from "./components/pages/shop/category_group/editor";
+import { ShopCategoryGroupListPage } from "./components/pages/shop/category_group/list";
+import { ShopOrderEditorPage } from "./components/pages/shop/order/editor";
+import { ShopOrderListPage } from "./components/pages/shop/order/list";
+import { ShopProductEditorPage } from "./components/pages/shop/product/editor";
+import { ShopProductListPage } from "./components/pages/shop/product/list";
+import { ShopTagListPage } from "./components/pages/shop/tag/list";
 import { SiteMapList } from "./components/pages/sitemap/list";
 import { AdminUserExtEditor } from "./components/pages/user/editor";
 
@@ -177,6 +188,41 @@ export const RouteDefinitions: RouteDef[] = [
     title: "발표",
     app: "event",
     resource: "presentation",
+  },
+  {
+    type: "separator",
+    key: "shop-separator",
+    title: "스토어",
+  },
+  {
+    type: "autoAdminRouteDefinition",
+    key: "shop-category-groups",
+    icon: FolderSpecial,
+    title: "카테고리 그룹",
+    app: "shop",
+    resource: "category-groups",
+  },
+  {
+    type: "autoAdminRouteDefinition",
+    key: "shop-tags",
+    icon: LocalOffer,
+    title: "태그",
+    app: "shop",
+    resource: "tags",
+  },
+  {
+    type: "routeDefinition",
+    key: "shop-product",
+    icon: ShoppingBag,
+    title: "상품",
+    route: "/shop/products",
+  },
+  {
+    type: "routeDefinition",
+    key: "shop-order",
+    icon: ReceiptLong,
+    title: "주문",
+    route: "/shop/orders",
   },
   {
     type: "separator",
@@ -328,4 +374,13 @@ export const RegisteredRoutes = {
   "/event/presentation/:id": <AdminPresentationEditor />,
   "/modification-audit": <AdminModificationAuditList />,
   "/modification-audit/modification-audit/:id": <AdminModificationAuditEditor />,
+  "/shop/category-groups": <ShopCategoryGroupListPage />,
+  "/shop/category-groups/create": <ShopCategoryGroupEditorPage />,
+  "/shop/category-groups/:id": <ShopCategoryGroupEditorPage />,
+  "/shop/tags": <ShopTagListPage />,
+  "/shop/products": <ShopProductListPage />,
+  "/shop/products/create": <ShopProductEditorPage />,
+  "/shop/products/:id": <ShopProductEditorPage />,
+  "/shop/orders": <ShopOrderListPage />,
+  "/shop/orders/:id": <ShopOrderEditorPage />,
 };

--- a/packages/common/src/apis/admin_api.ts
+++ b/packages/common/src/apis/admin_api.ts
@@ -8,6 +8,7 @@ import {
   OpenAPISchema,
   PageSectionBulkUpdateSchema,
   PageSectionSchema,
+  PaginatedListResponse,
   PublicFileSchema,
   UserChangePasswordSchema,
   UserResetPasswordResponseSchema,
@@ -39,6 +40,11 @@ export const list =
   <T>(client: BackendAPIClient, app: string, resource: string, params?: Record<string, string>) =>
   () =>
     client.get<T[]>(`v1/admin-api/${app}/${resource}/`, { params });
+
+export const listPaginated =
+  <T>(client: BackendAPIClient, app: string, resource: string, params?: Record<string, string>) =>
+  () =>
+    client.get<PaginatedListResponse<T>>(`v1/admin-api/${app}/${resource}/`, { params });
 
 export const retrieve =
   <T>(client: BackendAPIClient, app: string, resource: string, id: string) =>

--- a/packages/common/src/components/md_editor.tsx
+++ b/packages/common/src/components/md_editor.tsx
@@ -59,7 +59,7 @@ export const MarkdownEditor: React.FC<MDEditorProps> = ({ disabled, name, defaul
         commands.divider,
         commands.help,
       ]}
-      extraCommands={extraCommands}
+      extraCommands={extraCommands ?? []}
       style={TextEditorStyle}
     />
   </Stack>

--- a/packages/common/src/hooks/useAdminAPI.ts
+++ b/packages/common/src/hooks/useAdminAPI.ts
@@ -92,6 +92,12 @@ export const useListQuery = <T>(client: BackendAPIClient, app: string, resource:
     queryFn: BackendAdminAPIs.list<T>(client, app, resource, params),
   });
 
+export const useListPaginatedQuery = <T>(client: BackendAPIClient, app: string, resource: string, params?: Record<string, string>) =>
+  useSuspenseQuery({
+    queryKey: [...QUERY_KEYS.ADMIN_LIST, app, resource, "paginated", JSON.stringify(params)],
+    queryFn: BackendAdminAPIs.listPaginated<T>(client, app, resource, params),
+  });
+
 export const useRetrieveQuery = <T>(client: BackendAPIClient, app: string, resource: string, id: string) =>
   useSuspenseQuery({
     queryKey: [...QUERY_KEYS.ADMIN_RETRIEVE, app, resource, id],

--- a/packages/common/src/schemas/backendAdminAPI.ts
+++ b/packages/common/src/schemas/backendAdminAPI.ts
@@ -19,6 +19,13 @@ export type AdminSchemaDefinition = {
 
 export type ChoicesResponse = Record<string, { const: string | null; title: string }[]>;
 
+export type PaginatedListResponse<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
 export type UserSchema = {
   id: number;
   username: string;


### PR DESCRIPTION
## Summary

- pyconkr-admin에 스토어 운영 페이지 추가 — 태그, 카테고리 그룹, 상품, 주문 (`user/userext` editor에 주문 내역 섹션도 함께)
- 재사용 가능한 어드민 인프라 신설 — `AdminPagination`, `AdminFilterFieldset`, 공유 status labels
- `AdminList` 확장 — `columns` / `enableRowActions` / `title` (모두 하위호환 옵트인)
- `useListPaginatedQuery` hook + `PaginatedListResponse<T>` 타입 신설 (DRF PageNumberPagination 응답 처리)

## 페이지

| 페이지 | 라우트 | 구현 방식 |
|---|---|---|
| 태그 | `/shop/tags` | `AdminList` 커스텀 컬럼(매진 칩) + 기본 `AdminEditor` |
| 카테고리 그룹 | `/shop/category-groups` | `AdminList` + `AdminEditor` children에 자식 카테고리 inline Dialog |
| 상품 | `/shop/products` | 커스텀 list + 4탭 editor (기본/시간/가격/옵션그룹) |
| 주문 | `/shop/orders` | 커스텀 list (필터 fieldset 4그룹 + 페이지네이션) + 3탭 detail + 환불 다이얼로그(TOTP) + 알림 navigate |