### PR TITLE
fix: 어드민의 알림 전송 페이지에서 한국 전화번호 패턴도 허용하도록 수정

### DIFF
--- a/apps/pyconkr-admin/src/components/pages/notification/send_history_create.tsx
+++ b/apps/pyconkr-admin/src/components/pages/notification/send_history_create.tsx
@@ -90,10 +90,11 @@ const NotAppliableToAllRecipientsFieldList = [
 const URL_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)+([/?].*)?$/;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const INTERNATIONAL_PHONE_REGEX = /^\+\d{1,4}[-\s]?\d+(?:[-\s]?\d+)*$/;
+const KOREAN_PHONE_REGEX = /^01[016-9][-\s]?\d{3,4}[-\s]?\d{4}$/;
 
 const isValidEmail = (value: string) => EMAIL_REGEX.test(value);
 const isValidUrl = (value: string) => URL_REGEX.test(value);
-const isValidPhone = (value: string) => URL_REGEX.test(value) || INTERNATIONAL_PHONE_REGEX.test(value);
+const isValidPhone = (value: string) => KOREAN_PHONE_REGEX.test(value) || INTERNATIONAL_PHONE_REGEX.test(value);
 
 const validateRecipientForApp = (app: NotificationChannelApp, value: string): string | null => {
   const trimmed = value.trim();


### PR DESCRIPTION
# 주요 변경 사항
- 제곧내입니다, 알림 전송 페이지에서 한국 전화번호 패턴(01011112222 or 010-1111-2222 등)을 허용하지 않아, 허용하도록 수정합니다.

# 추가 사항
- #58 브랜치를 기반으로 작업되어, 해당 브랜치를 base 브랜치로 설정합니다.
  추후 저 브랜치가 main에 머지된 후 본 브랜치도 머지할 예정입니다.