### PR TITLE
fix: 어드민의 유저 에디터 페이지에서 스토어 주문 내역이 표시되지 않던 문제 수정

### DIFF
--- a/apps/pyconkr-admin/src/components/pages/user/shop_order_section.tsx
+++ b/apps/pyconkr-admin/src/components/pages/user/shop_order_section.tsx
@@ -1,4 +1,4 @@
-import { useBackendAdminClient, useListQuery } from "@frontend/common/hooks/useAdminAPI";
+import { useBackendAdminClient, useListPaginatedQuery } from "@frontend/common/hooks/useAdminAPI";
 import { Alert, Chip, CircularProgress, Divider, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import { FC } from "react";
@@ -24,8 +24,8 @@ const InnerShopOrderSection: FC<{ userId: string }> = ErrorBoundary.with(
   { fallback: ErrorFallback },
   Suspense.with({ fallback: <CircularProgress /> }, ({ userId }) => {
     const client = useBackendAdminClient();
-    const ordersQuery = useListQuery<OrderListRow>(client, "shop", "orders", { user_id: userId });
-    const orders = ordersQuery.data ?? [];
+    const ordersQuery = useListPaginatedQuery<OrderListRow>(client, "shop", "orders", { user_id: userId });
+    const orders = ordersQuery.data?.results ?? [];
 
     return (
       <Stack spacing={2} sx={{ mt: 4 }}>


### PR DESCRIPTION
# 주요 변경 사항
- 사용자 페이지에서 주문 목록이 제대로 노출되지 않던 문제를 수정합니다.
  - 08ee3ddbc0c2982646db702ded10be32dd1fe710 커밋에서 Order list API에 pagination이 적용됐으나, 본 페이지는 수정하지 않음

# 추가 사항
- #58 브랜치를 기반으로 작업되어, 해당 브랜치를 base 브랜치로 설정합니다.
  추후 저 브랜치가 main에 머지된 후 본 브랜치도 머지할 예정입니다.