### PR TITLE
fix: pyconkr-2026 헤더 네비게이션 레이아웃 개선

### DIFF
--- a/apps/pyconkr-2026/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr-2026/src/components/layout/Header/index.tsx
@@ -211,9 +211,8 @@ const HeaderContainer = styled("header")(({ theme }) => ({
 }));
 
 const HeaderInner = styled("div")(({ theme }) => ({
-  display: "flex",
-  flexDirection: "row",
-  justifyContent: "space-between",
+  display: "grid",
+  gridTemplateColumns: "1fr auto 1fr",
   alignItems: "center",
   width: "100%",
   height: "100%",
@@ -232,7 +231,10 @@ const NavButton = styled(Button)<{ isActive?: boolean }>(({ isActive }) => ({
   "&:hover": { color: "#ed5ebd", backgroundColor: "transparent" },
 }));
 
-const NavSideElementContainer = styled(Stack)();
+const NavSideElementContainer = styled(Stack)({
+  flexDirection: "row",
+  alignItems: "center",
+});
 
 const NavDropdownOuter = styled(Stack)(({ theme }) => ({
   width: "100vw",

--- a/apps/pyconkr-2026/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr-2026/src/components/layout/Header/index.tsx
@@ -23,6 +23,7 @@ type NavigationStateType = {
 
 const HeaderHeight: CSSProperties["height"] = "3.625rem";
 const BreadCrumbHeight: CSSProperties["height"] = "4.5rem";
+const MaxContentWidth: CSSProperties["maxWidth"] = "1366px";
 
 export default function Header() {
   const { title, language, siteMapNode, currentSiteMapDepth, shouldShowTitleBanner } = useAppContext();
@@ -51,42 +52,44 @@ export default function Header() {
   return (
     <Box sx={{ position: "relative" }} onMouseLeave={resetDepths}>
       <HeaderContainer sx={headerStyle}>
-        <NavSideElementContainer>
-          <Link to="/" onClick={resetDepths}>
-            <Stack direction="row" alignItems="center" spacing={0.75}>
-              <PythonKorea style={{ width: 36, height: 36 }} />
-              <Typography className="header-title-text" sx={{ color: "#ededde", fontWeight: 600, fontSize: "1rem", letterSpacing: "0.01em" }}>
-                PyCon Korea 2026
-              </Typography>
+        <HeaderInner>
+          <NavSideElementContainer>
+            <Link to="/" onClick={resetDepths}>
+              <Stack direction="row" alignItems="center" spacing={0.75}>
+                <PythonKorea style={{ width: 36, height: 36 }} />
+                <Typography className="header-title-text" sx={{ color: "#ededde", fontWeight: 600, fontSize: "1rem" }}>
+                  PyCon Korea 2026
+                </Typography>
+              </Stack>
+            </Link>
+          </NavSideElementContainer>
+
+          {siteMapNode ? (
+            <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5}>
+              {Object.values(siteMapNode.children)
+                .filter((s) => !s.hide)
+                .map((r) => (
+                  <Link
+                    key={r.id}
+                    onClick={resetDepths}
+                    target={isString(r.external_link) ? "_blank" : undefined}
+                    rel={isString(r.external_link) ? "noopener noreferrer" : undefined}
+                    to={r.external_link || r.route_code}
+                  >
+                    <NavButton onMouseEnter={() => setDepth1(r)} isActive={navState.depth1?.id === r.id}>
+                      {r.name}
+                    </NavButton>
+                  </Link>
+                ))}
             </Stack>
-          </Link>
-        </NavSideElementContainer>
+          ) : (
+            <CircularProgress size={24} sx={{ color: "#ed5ebd" }} />
+          )}
 
-        {siteMapNode ? (
-          <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5}>
-            {Object.values(siteMapNode.children)
-              .filter((s) => !s.hide)
-              .map((r) => (
-                <Link
-                  key={r.id}
-                  onClick={resetDepths}
-                  target={isString(r.external_link) ? "_blank" : undefined}
-                  rel={isString(r.external_link) ? "noopener noreferrer" : undefined}
-                  to={r.external_link || r.route_code}
-                >
-                  <NavButton onMouseEnter={() => setDepth1(r)} isActive={navState.depth1?.id === r.id}>
-                    {r.name}
-                  </NavButton>
-                </Link>
-              ))}
-          </Stack>
-        ) : (
-          <CircularProgress size={24} sx={{ color: "#ed5ebd" }} />
-        )}
-
-        <NavSideElementContainer sx={{ justifyContent: "flex-end" }}>
-          <LanguageSelector />
-        </NavSideElementContainer>
+          <NavSideElementContainer sx={{ justifyContent: "flex-end" }}>
+            <LanguageSelector />
+          </NavSideElementContainer>
+        </HeaderInner>
       </HeaderContainer>
 
       {navState.depth1 && (
@@ -147,22 +150,24 @@ export default function Header() {
       {shouldShowTitleBanner && (
         <>
           <BreadCrumbContainer>
-            <Stack direction="row" alignItems="center" spacing={0.5}>
-              {breadCrumbArray
-                .filter((routeInfo) => isNonNullish(routeInfo))
-                .map(({ route_code, name }, index) => {
-                  breadCrumbRoute += `${route_code}/`;
-                  return (
-                    <Fragment key={index}>
-                      {index > 0 && <ArrowForwardIos sx={{ fontSize: "0.75rem", color: "rgba(237,94,189,0.6)" }} />}
-                      <Link to={breadCrumbRoute} children={name} />
-                    </Fragment>
-                  );
-                })}
-            </Stack>
-            <Typography variant="h1" sx={{ fontSize: "1.625rem", fontWeight: 700, color: "#ededde" }}>
-              {title}
-            </Typography>
+            <BreadCrumbInner>
+              <Stack direction="row" alignItems="center" spacing={0.5}>
+                {breadCrumbArray
+                  .filter((routeInfo) => isNonNullish(routeInfo))
+                  .map(({ route_code, name }, index) => {
+                    breadCrumbRoute += `${route_code}/`;
+                    return (
+                      <Fragment key={index}>
+                        {index > 0 && <ArrowForwardIos sx={{ fontSize: "0.75rem", color: "rgba(237,94,189,0.6)" }} />}
+                        <Link to={breadCrumbRoute} children={name} />
+                      </Fragment>
+                    );
+                  })}
+              </Stack>
+              <Typography variant="h1" sx={{ fontSize: "1.625rem", fontWeight: 700, color: "#ededde" }}>
+                {title}
+              </Typography>
+            </BreadCrumbInner>
           </BreadCrumbContainer>
           <Box sx={{ height: `calc(${HeaderHeight} + ${BreadCrumbHeight})` }} />
         </>
@@ -180,10 +185,6 @@ const ResponsivePadding = ({ theme }: MUIStyledCommonProps) => ({
 
 const HeaderContainer = styled("header")(({ theme }) => ({
   position: "fixed",
-  display: "flex",
-  flexDirection: "row",
-  justifyContent: "space-between",
-  alignItems: "center",
   width: "100%",
   height: HeaderHeight,
   backgroundColor: "rgba(18, 9, 30, 0.85)",
@@ -201,6 +202,17 @@ const HeaderContainer = styled("header")(({ theme }) => ({
   "&:hover .header-title-text": {
     opacity: 1,
   },
+}));
+
+const HeaderInner = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  width: "100%",
+  height: "100%",
+  maxWidth: MaxContentWidth,
+  marginInline: "auto",
   ...ResponsivePadding({ theme }),
 }));
 
@@ -214,7 +226,7 @@ const NavButton = styled(Button)<{ isActive?: boolean }>(({ isActive }) => ({
   "&:hover": { color: "#ed5ebd", backgroundColor: "transparent" },
 }));
 
-const NavSideElementContainer = styled(Stack)({ flexGrow: 1, flexBasis: 0 });
+const NavSideElementContainer = styled(Stack)();
 
 const NavDropdownOuter = styled(Stack)(({ theme }) => ({
   width: "100vw",
@@ -231,6 +243,8 @@ const NavDropdownOuter = styled(Stack)(({ theme }) => ({
 
 const NavDropdownInner = styled(Stack)(({ theme }) => ({
   width: "100%",
+  maxWidth: MaxContentWidth,
+  marginInline: "auto",
   minHeight: "10rem",
   overflowY: "auto",
   gap: "1rem",
@@ -261,7 +275,7 @@ const Depth2to3Divider = styled(Divider)({ borderColor: "rgba(237, 94, 189, 0.3)
 
 const Depth3Item = styled(Depth2Item)({ fontSize: "0.75rem" });
 
-const BreadCrumbContainer = styled(Stack)(({ theme }) => ({
+const BreadCrumbContainer = styled("div")(({ theme }) => ({
   position: "fixed",
   top: HeaderHeight,
   width: "100%",
@@ -271,10 +285,17 @@ const BreadCrumbContainer = styled(Stack)(({ theme }) => ({
   backdropFilter: "blur(10px)",
   WebkitBackdropFilter: "blur(10px)",
   borderBottom: "1px solid rgba(237, 94, 189, 0.15)",
+  zIndex: theme.zIndex.appBar - 1,
+}));
+
+const BreadCrumbInner = styled(Stack)(({ theme }) => ({
+  width: "100%",
+  height: "100%",
+  maxWidth: MaxContentWidth,
+  marginInline: "auto",
   gap: "0.25rem",
   justifyContent: "center",
   alignItems: "flex-start",
-  zIndex: theme.zIndex.appBar - 1,
   ...ResponsivePadding({ theme }),
   "& a": {
     color: "#f5c73d",

--- a/apps/pyconkr-2026/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr-2026/src/components/layout/Header/index.tsx
@@ -50,7 +50,13 @@ export default function Header() {
   const headerStyle: SxProps<Theme> = shouldShowTitleBanner ? {} : { backgroundColor: "transparent" };
 
   return (
-    <Box sx={{ position: "relative" }} onMouseLeave={resetDepths}>
+    <Box
+      sx={{
+        position: "relative",
+        "&:has(.nav-dropdown:hover) .header-title-text": { opacity: 1 },
+      }}
+      onMouseLeave={resetDepths}
+    >
       <HeaderContainer sx={headerStyle}>
         <HeaderInner>
           <NavSideElementContainer>
@@ -93,7 +99,7 @@ export default function Header() {
       </HeaderContainer>
 
       {navState.depth1 && (
-        <NavDropdownOuter>
+        <NavDropdownOuter className="nav-dropdown">
           <NavDropdownInner>
             <Typography variant="h2" sx={{ fontSize: "1.5rem", fontWeight: 700, color: "#ededde" }}>
               {navState.depth1.name}

--- a/apps/pyconkr-2026/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr-2026/src/components/layout/Header/index.tsx
@@ -202,7 +202,8 @@ const HeaderContainer = styled("header")(({ theme }) => ({
   zIndex: theme.zIndex.appBar,
   transition: "background-color 0.3s ease-in-out",
   "& .header-title-text": {
-    opacity: 0,
+    // TODO: FIXME: HeaderInner의 좌측 정렬 모드를 중앙 정렬("1fr auto 1fr")로 되돌릴 때 opacity를 다시 0으로 변경할 것 (hover 시에만 노출되는 원래 동작 복귀)
+    opacity: 1,
     transition: "opacity 0.2s ease",
   },
   "&:hover .header-title-text": {
@@ -212,7 +213,9 @@ const HeaderContainer = styled("header")(({ theme }) => ({
 
 const HeaderInner = styled("div")(({ theme }) => ({
   display: "grid",
-  gridTemplateColumns: "1fr auto 1fr",
+  // TODO: FIXME: sitemap 항목이 충분히 등록되면 gridTemplateColumns를 "1fr auto 1fr"로 되돌려 중앙 정렬로 복귀하고, columnGap도 제거할 것
+  gridTemplateColumns: "auto auto 1fr",
+  columnGap: theme.spacing(2),
   alignItems: "center",
   width: "100%",
   height: "100%",


### PR DESCRIPTION
## Summary

<img width="864" height="542" src="https://github.com/user-attachments/assets/5fcd37a0-c562-4026-911f-380ffae2b4ee" />

- 화면 너비가 1366px 이상이 되면 양쪽 `NavSideElementContainer`가 더 이상 벌어지지 않도록 수정
  - `HeaderInner`/`NavDropdownInner`/`BreadCrumbInner`에 `max-width: 1366px` + 중앙 정렬 적용
- `HeaderInner`를 `display: grid; gridTemplateColumns: 1fr auto 1fr`로 전환하여 양쪽 사이드가 동일 폭을 갖고
  가운데 sitemap이 진짜 가운데 정렬되도록 수정
- `NavDropdownOuter` hover 시에도 "PyCon Korea 2026" 타이틀 텍스트가 보이도록
  outer Box에 `:has(.nav-dropdown:hover) .header-title-text { opacity: 1 }` 규칙 추가
- (임시) sitemap 항목이 충분히 등록되기 전까지는 nav를 좌측 정렬(`auto auto 1fr`)하고 타이틀 텍스트를 상시 노출.
  두 변경 모두 TODO/FIXME 주석으로 복귀 방법 명시
  - sitemap이 너무 등록되어 있지 않다보니 휑해보이더라고요...
    우선 임시로 이렇게 해두고, 나중에 2025년처럼 어느 정도 많이 등록되면 중앙정렬 / 타이틀 텍스트 상시 정렬을 복구하려 합니다.

# 추가 사항
- #58 브랜치를 기반으로 작업되어, 해당 브랜치를 base 브랜치로 설정합니다.
  추후 저 브랜치가 main에 머지된 후 본 브랜치도 머지할 예정입니다.