### PR TITLE
fix : 2026 헤더 메뉴 글자 전환점 변경

### DIFF
--- a/apps/pyconkr-2026/src/components/layout/Header/index.tsx
+++ b/apps/pyconkr-2026/src/components/layout/Header/index.tsx
@@ -30,7 +30,7 @@ const MaxContentWidth: CSSProperties["maxWidth"] = "1366px";
 export default function Header() {
   const { title, language, siteMapNode, currentSiteMapDepth, shouldShowTitleBanner } = useAppContext();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const [navState, setNavState] = useState<NavigationStateType>({});
 
   const resetDepths = () => setNavState({});
@@ -68,7 +68,7 @@ export default function Header() {
             </Link>
           </NavSideElementContainer>
           {siteMapNode ? (
-            <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5}>
+            <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5} sx={{ minWidth: 0 }}>
               {Object.values(siteMapNode.children)
                 .filter((s) => !s.hide)
                 .map((r) => (
@@ -229,21 +229,26 @@ const HeaderContainer = styled("header")(({ theme }) => ({
 
 const HeaderInner = styled("div")(({ theme }) => ({
   display: "grid",
-  gridTemplateColumns: "1fr auto 1fr",
+  gridTemplateColumns: "auto minmax(0, 1fr) auto",
   alignItems: "center",
+  columnGap: theme.spacing(2),
   width: "100%",
   height: "100%",
   maxWidth: MaxContentWidth,
   marginInline: "auto",
-  ...ResponsivePaddingDefinition({ theme }),
+  paddingRight: theme.spacing(2),
+  paddingLeft: theme.spacing(2),
+  whiteSpace: "nowrap",
 }));
 
 const NavButton = styled(Button)<{ isActive?: boolean }>(({ theme, isActive }) => ({
   color: isActive ? theme.palette.primary.main : theme.palette.text.primary,
   minWidth: 0,
+  paddingInline: theme.spacing(0.75),
   textTransform: "none",
-  fontSize: "0.9rem",
+  fontSize: "0.75rem",
   fontWeight: isActive ? 700 : 400,
+  whiteSpace: "nowrap",
   transition: "color 0.2s ease",
   "&:hover": { color: theme.palette.primary.main, backgroundColor: "transparent" },
 }));


### PR DESCRIPTION
### 내용
- 슬랙 버그 제보에 올라온 내용 수정
> 화면의 가로 크기가 900px 이상일 때 상단 메뉴바의 글자의 CSS 깨지는 현상
> 영문 같이 텍스트가 길면 더 그러는 것 같습니다.


### 변경 사항
<img width="1432" height="153" alt="image" src="https://github.com/user-attachments/assets/8a273c03-bb81-4e40-949f-5526863eaf6e" />


- 2026 사이트 데스크톱 헤더 전환점을 `md`에서 `lg`로 변경했습니다.
- 헤더 내부 그리드/패딩을 조정해 메뉴 영역이 좁은 폭에서 불필요하게 줄어들지 않도록 했습니다.
- 긴 영문 메뉴 텍스트가 줄바꿈되어 상단 메뉴바가 깨지는 문제를 막기 위해 메뉴 버튼에 `white-space: nowrap`을 적용했습니다.
